### PR TITLE
Reorganize state module imports and visibility in token program

### DIFF
--- a/programs/token/src/state/mod.rs
+++ b/programs/token/src/state/mod.rs
@@ -1,8 +1,7 @@
-pub mod token;
-pub use token::*;
+mod account_state;
+mod mint;
+mod token;
 
-pub mod mint;
-pub use mint::*;
-
-pub mod account_state;
 pub use account_state::*;
+pub use mint::*;
+pub use token::*;


### PR DESCRIPTION
Actually, it's a bit weird to export the module and the types it contains to the super module