### PR TITLE
log: Add support for `usize` and `isize`

### DIFF
--- a/sdk/log/crate/src/lib.rs
+++ b/sdk/log/crate/src/lib.rs
@@ -206,4 +206,60 @@ mod tests {
         logger.append_with_args("0123456789", &[Argument::TruncateStart(9)]);
         assert!(&*logger == "..@".as_bytes());
     }
+
+    #[test]
+    fn test_logger_with_usize() {
+        let mut logger = Logger::<20>::default();
+
+        logger.append(usize::MIN);
+        assert!(&*logger == "0".as_bytes());
+
+        logger.clear();
+
+        logger.append(usize::MAX);
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            assert!(&*logger == "4294967295".as_bytes());
+            assert_eq!(logger.len(), 10);
+        }
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert!(&*logger == "18446744073709551615".as_bytes());
+            assert_eq!(logger.len(), 20);
+        }
+    }
+
+    #[test]
+    fn test_logger_with_isize() {
+        let mut logger = Logger::<20>::default();
+
+        logger.append(isize::MIN);
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            assert!(&*logger == "-2147483648".as_bytes());
+            assert_eq!(logger.len(), 11);
+        }
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert!(&*logger == "-9223372036854775808".as_bytes());
+            assert_eq!(logger.len(), 20);
+        }
+
+        logger.clear();
+
+        logger.append(isize::MAX);
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            assert!(&*logger == "2147483647".as_bytes());
+            assert_eq!(logger.len(), 10);
+        }
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert!(&*logger == "9223372036854775807".as_bytes());
+            assert_eq!(logger.len(), 19);
+        }
+    }
 }

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -366,10 +366,6 @@ impl_log_for_signed!(i16);
 impl_log_for_signed!(i32);
 impl_log_for_signed!(i64);
 impl_log_for_signed!(i128);
-// Handle the `isize` type.
-#[cfg(target_pointer_width = "32")]
-impl_log_for_signed!(isize);
-#[cfg(target_pointer_width = "64")]
 impl_log_for_signed!(isize);
 
 /// Implement the log trait for the &str type.

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -324,7 +324,7 @@ impl_log_for_unsigned_integer!(usize, 20);
 
 /// Implement the log trait for the signed integer types.
 macro_rules! impl_log_for_signed {
-    ( $type:tt, $unsigned_type:tt, $max_digits:literal ) => {
+    ( $type:tt ) => {
         impl Log for $type {
             #[inline]
             fn write_with_args(&self, buffer: &mut [MaybeUninit<u8>], args: &[Argument]) -> usize {
@@ -340,7 +340,7 @@ macro_rules! impl_log_for_signed {
                         }
                         1
                     }
-                    mut value => {
+                    value => {
                         let mut prefix = 0;
 
                         if *self < 0 {
@@ -348,11 +348,11 @@ macro_rules! impl_log_for_signed {
                                 buffer.get_unchecked_mut(0).write(b'-');
                             }
                             prefix += 1;
-                            value = -value
                         };
 
                         prefix
-                            + (value as $unsigned_type).write_with_args(&mut buffer[prefix..], args)
+                            + $type::unsigned_abs(value)
+                                .write_with_args(&mut buffer[prefix..], args)
                     }
                 }
             }
@@ -361,16 +361,16 @@ macro_rules! impl_log_for_signed {
 }
 
 // Supported signed integer types.
-impl_log_for_signed!(i8, u8, 3);
-impl_log_for_signed!(i16, u16, 5);
-impl_log_for_signed!(i32, u32, 10);
-impl_log_for_signed!(i64, u64, 19);
-impl_log_for_signed!(i128, u128, 39);
+impl_log_for_signed!(i8);
+impl_log_for_signed!(i16);
+impl_log_for_signed!(i32);
+impl_log_for_signed!(i64);
+impl_log_for_signed!(i128);
 // Handle the `isize` type.
 #[cfg(target_pointer_width = "32")]
-impl_log_for_signed!(isize, usize, 10);
+impl_log_for_signed!(isize);
 #[cfg(target_pointer_width = "64")]
-impl_log_for_signed!(isize, usize, 19);
+impl_log_for_signed!(isize);
 
 /// Implement the log trait for the &str type.
 impl Log for &str {

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -316,6 +316,11 @@ impl_log_for_unsigned_integer!(u16, 5);
 impl_log_for_unsigned_integer!(u32, 10);
 impl_log_for_unsigned_integer!(u64, 20);
 impl_log_for_unsigned_integer!(u128, 39);
+// Handle the `usize` type.
+#[cfg(target_pointer_width = "32")]
+impl_log_for_unsigned_integer!(usize, 10);
+#[cfg(target_pointer_width = "64")]
+impl_log_for_unsigned_integer!(usize, 20);
 
 /// Implement the log trait for the signed integer types.
 macro_rules! impl_log_for_signed {
@@ -361,6 +366,11 @@ impl_log_for_signed!(i16, u16, 5);
 impl_log_for_signed!(i32, u32, 10);
 impl_log_for_signed!(i64, u64, 19);
 impl_log_for_signed!(i128, u128, 39);
+// Handle the `isize` type.
+#[cfg(target_pointer_width = "32")]
+impl_log_for_signed!(isize, usize, 10);
+#[cfg(target_pointer_width = "64")]
+impl_log_for_signed!(isize, usize, 19);
 
 /// Implement the log trait for the &str type.
 impl Log for &str {

--- a/sdk/log/crate/src/logger.rs
+++ b/sdk/log/crate/src/logger.rs
@@ -17,7 +17,7 @@ const DIGITS: [u8; 10] = [b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', 
 const TRUNCATED_SLICE: [u8; 3] = [b'.', b'.', b'.'];
 
 /// Byte representing a truncated log.
-const TRUCATED: u8 = b'@';
+const TRUNCATED: u8 = b'@';
 
 /// An uninitialized byte.
 const UNINIT_BYTE: MaybeUninit<u8> = MaybeUninit::uninit();
@@ -68,7 +68,7 @@ impl<const BUFFER: usize> Logger<BUFFER> {
             if BUFFER > 0 {
                 unsafe {
                     let last = self.buffer.get_unchecked_mut(BUFFER - 1);
-                    last.write(TRUCATED);
+                    last.write(TRUNCATED);
                 }
             }
         } else {
@@ -299,7 +299,7 @@ macro_rules! impl_log_for_unsigned_integer {
                         if overflow {
                             unsafe {
                                 let last = buffer.get_unchecked_mut(written - 1);
-                                last.write(TRUCATED);
+                                last.write(TRUNCATED);
                             }
                         }
                         written
@@ -379,7 +379,7 @@ impl Log for &str {
 
         match buffer.len() - offset {
             0 => unsafe {
-                buffer.get_unchecked_mut(offset - 1).write(TRUCATED);
+                buffer.get_unchecked_mut(offset - 1).write(TRUNCATED);
             },
             _ => {
                 unsafe {
@@ -487,7 +487,7 @@ impl Log for &str {
         if truncated {
             unsafe {
                 let last = buffer.get_unchecked_mut(length - 1);
-                last.write(TRUCATED);
+                last.write(TRUNCATED);
             }
         }
 
@@ -532,7 +532,7 @@ macro_rules! impl_log_for_slice {
             for value in self.iter() {
                 if offset >= length {
                     unsafe {
-                        buffer.get_unchecked_mut(length - 1).write(TRUCATED);
+                        buffer.get_unchecked_mut(length - 1).write(TRUNCATED);
                     }
                     offset = length;
                     break;
@@ -541,7 +541,7 @@ macro_rules! impl_log_for_slice {
                 if offset > 1 {
                     if offset + 2 >= length {
                         unsafe {
-                            buffer.get_unchecked_mut(length - 1).write(TRUCATED);
+                            buffer.get_unchecked_mut(length - 1).write(TRUNCATED);
                         }
                         offset = length;
                         break;


### PR DESCRIPTION
### Problem

To log `usize` and `isize` values, it is necessary to convert them to `u64` and `i64`, respectively.

### Solution

Add support for logging `usize` and `isize` values directly.