### PR TITLE
add `seeds` macro

### DIFF
--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -251,6 +251,28 @@ impl<'a, 'b, const SIZE: usize> From<&'b [Seed<'a>; SIZE]> for Signer<'a, 'b> {
     }
 }
 
+/// Convenience macro for constructing a `Signer` from a list of seeds
+/// represented as byte slices.
+///
+/// # Example
+///
+/// Creating a signer for a PDA with a single seed and bump value:
+/// ```
+/// use pinocchio::signer;
+///
+/// let pda_bump = 255;
+/// let signer = signer!(b"seed", &[pda_bump]);
+/// ```
+#[macro_export]
+#[deprecated(since = "0.8.0", note = "Use `seeds!` macro instead")]
+macro_rules! signer {
+    ( $($seed:expr),* ) => {
+            $crate::instruction::Signer::from(&[$(
+                $seed.into(),
+            )*])
+    };
+}
+
 /// Convenience macro for constructing a `[Seed; N]` array from a list of seeds.
 ///
 /// # Example

--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -251,23 +251,25 @@ impl<'a, 'b, const SIZE: usize> From<&'b [Seed<'a>; SIZE]> for Signer<'a, 'b> {
     }
 }
 
-/// Convenience macro for constructing a `Signer` from a list of seeds
-/// represented as byte slices.
+/// Convenience macro for constructing a `[Seed; N]` array from a list of seeds.
 ///
 /// # Example
 ///
-/// Creating a signer for a PDA with a single seed and bump value:
+/// Creating seeds array and signer for a PDA with a single seed and bump value:
 /// ```
-/// use pinocchio::signer;
+/// use pinocchio::{seeds, Signer};
+/// use pinocchio::pubkey::find_program_address;
 ///
-/// let pda_bump = 255;
-/// let signer = signer!(b"seed", &[pda_bump]);
+/// let pda_bump = find_program_address(&[b"seed"], &some_key).1;
+/// let pda_ref = &[pda_bump];  // prevent temporary value being freed
+/// let seeds = seeds!(b"seed", &some_key, pda_ref);
+/// let signer = Signer::from(&seeds);
 /// ```
 #[macro_export]
-macro_rules! signer {
+macro_rules! seeds {
     ( $($seed:expr),* ) => {
-            $crate::instruction::Signer::from(&[$(
-                $seed.into(),
-            )*])
+        [$(
+            $crate::instruction::Seed::from($seed),
+        )*]
     };
 }

--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -257,12 +257,13 @@ impl<'a, 'b, const SIZE: usize> From<&'b [Seed<'a>; SIZE]> for Signer<'a, 'b> {
 ///
 /// Creating seeds array and signer for a PDA with a single seed and bump value:
 /// ```
-/// use pinocchio::{seeds, Signer};
-/// use pinocchio::pubkey::find_program_address;
+/// use pinocchio::{seeds, instruction::Signer};
+/// use pinocchio::pubkey::Pubkey;
 ///
-/// let pda_bump = find_program_address(&[b"seed"], &some_key).1;
+/// let pda_bump = 0xffu8;
 /// let pda_ref = &[pda_bump];  // prevent temporary value being freed
-/// let seeds = seeds!(b"seed", &some_key, pda_ref);
+/// let example_key = Pubkey::default();
+/// let seeds = seeds!(b"seed", &example_key, pda_ref);
 /// let signer = Signer::from(&seeds);
 /// ```
 #[macro_export]


### PR DESCRIPTION
fixes #72 

for the two examples mentioned in the issue
```rust
// example 1
let bump_seed = Seed::from(&[255]);
let signer = Signer::from(&[bump_seed]);
let _ = signer;

// example 2 using `signer` macro
let signer = signer!(b"seed", &[255]);
ix.invoke_signed(&[signer])?;
```

we now can
```rust
// example 1
let seeds = seeds!(&[255u8]);
let signer = Signer::from(&seeds);
let _ = signer;

// example 2
let seeds = seeds!(b"seed", &[255]);
let signer = Signer::from(&seeds);
ix.invoke_signed(&[signer])?;
```