### PR TITLE
Remove `mut` from lazy entrypoint context helper

### DIFF
--- a/sdk/pinocchio/src/entrypoint/lazy.rs
+++ b/sdk/pinocchio/src/entrypoint/lazy.rs
@@ -175,7 +175,7 @@ impl InstructionContext {
     /// This method can only be used after all accounts have been read; otherwise, it will
     /// return a [`ProgramError::InvalidInstructionData`] error.
     #[inline(always)]
-    pub fn instruction_data(&mut self) -> Result<&[u8], ProgramError> {
+    pub fn instruction_data(&self) -> Result<&[u8], ProgramError> {
         if self.remaining > 0 {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -190,7 +190,7 @@ impl InstructionContext {
     /// It is up to the caller to guarantee that all accounts have been read; calling this method
     /// before reading all accounts will result in undefined behavior.
     #[inline(always)]
-    pub unsafe fn instruction_data_unchecked(&mut self) -> &[u8] {
+    pub unsafe fn instruction_data_unchecked(&self) -> &[u8] {
         let data_len = *(self.input.add(self.offset) as *const usize);
         // shadowing the offset to avoid leaving it in an inconsistent state
         let offset = self.offset + core::mem::size_of::<u64>();
@@ -202,7 +202,7 @@ impl InstructionContext {
     /// This method can only be used after all accounts have been read; otherwise, it will
     /// return a [`ProgramError::InvalidInstructionData`] error.
     #[inline(always)]
-    pub fn program_id(&mut self) -> Result<&Pubkey, ProgramError> {
+    pub fn program_id(&self) -> Result<&Pubkey, ProgramError> {
         if self.remaining > 0 {
             return Err(ProgramError::InvalidInstructionData);
         }
@@ -217,9 +217,8 @@ impl InstructionContext {
     /// It is up to the caller to guarantee that all accounts have been read; calling this method
     /// before reading all accounts will result in undefined behavior.
     #[inline(always)]
-    pub unsafe fn program_id_unchecked(&mut self) -> &Pubkey {
+    pub unsafe fn program_id_unchecked(&self) -> &Pubkey {
         let data_len = *(self.input.add(self.offset) as *const usize);
-        // shadowing the offset to avoid leaving it in an inconsistent state
         &*(self
             .input
             .add(self.offset + core::mem::size_of::<u64>() + data_len) as *const Pubkey)


### PR DESCRIPTION
### Problem

Both `instruction_data` and `program_id` context helpers of the lazy entrypoint require a `&mut` reference. This is unnecessary since these helpers do not modify the context.

### Solution

Remove the unnecessary `mut` requirement.