### PR TITLE
use `get_unchecked` over [] to prevent `fmt` code emission

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -173,7 +173,8 @@ pub unsafe fn deserialize<'a, const MAX_ACCOUNTS: usize>(
                 accounts[i].write(AccountInfo { raw: account_info });
             } else {
                 offset += core::mem::size_of::<u64>();
-                // duplicate account, clone the original pointer
+                // duplicated account – clone the original pointer using `borrow_state` since it represents the
+                // index of the duplicated account passed by the runtime.
                 accounts[i].write(
                     accounts
                         .get_unchecked((*account_info).borrow_state as usize)

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -175,7 +175,8 @@ pub unsafe fn deserialize<'a, const MAX_ACCOUNTS: usize>(
                 offset += core::mem::size_of::<u64>();
                 // duplicate account, clone the original pointer
                 accounts[i].write(
-                    accounts[(*account_info).borrow_state as usize]
+                    accounts
+                        .get_unchecked((*account_info).borrow_state as usize)
                         .assume_init_ref()
                         .clone(),
                 );


### PR DESCRIPTION
using `[]` will let rustc generate `panic_bounds_check`, which subsequently generate 

```
core::fmt::num::imp::<impl core::fmt::Display for usize>::fmt
core::fmt::num::imp::fmt_u64
core::fmt::Formatter::pad_integral
core::fmt::Formatter::pad_integral::write_prefix
core::str::count::do_count_chars
```

before the commit, an empty program that does nothing will generate 575 EBPF instructions. after it only has 32. 

`cargo build-sbf --verbose --dump && cat ./target/deploy/pinocchio_test-dump.txt | grep -E "\b[0-9a-fA-F]{2} [0-9a-fA-F]{2} [0-9a-fA-F]{2}\b" | grep -v Magic | wc -l`

for safety, i think `borrow_state` is passed in by the svm which we can assume correctness.