### PR TITLE
 Fix Grammar and Typographical Errors in Documentation

### DIFF
--- a/programs/associated-token-account/README.md
+++ b/programs/associated-token-account/README.md
@@ -13,7 +13,7 @@
 
 This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for SPL Associated Token Account program instructions.
 
-Each instruction defines an `struct` with the accounts and parameters required. Once all values are set, you can call directly `invoke` or `invoke_signed` to perform the CPI.
+Each instruction defines a `struct` with the accounts and parameters required. Once all values are set, you can call directly `invoke` or `invoke_signed` to perform the CPI.
 
 This is a `no_std` crate.
 

--- a/programs/token/README.md
+++ b/programs/token/README.md
@@ -2,7 +2,7 @@
 
 This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for SPL Token instructions.
 
-Each instruction defines an `struct` with the accounts and parameters required. Once all values are set, you can call directly `invoke` or `invoke_signed` to perform the CPI.
+Each instruction defines a `struct` with the accounts and parameters required. Once all values are set, you can call directly `invoke` or `invoke_signed` to perform the CPI.
 
 This is a `no_std` crate.
 

--- a/sdk/log/macro/README.md
+++ b/sdk/log/macro/README.md
@@ -26,7 +26,7 @@ use pinocchio_log::log
 log!("a simple log");
 ```
 
-To ouput a formatted message:
+To output a formatted message:
 ```rust
 use pinocchio_log::log
 
@@ -50,7 +50,7 @@ let lamports = 1_000_000_000;
 log!("transfer amount (SOL: {:.9}", lamports);
 ```
 
-For `&str` types, it is possible to specify a maximim length and a truncation strategy:
+For `&str` types, it is possible to specify a maximum length and a truncation strategy:
 ```rust
 use pinocchio_log::log
 


### PR DESCRIPTION
Correction of "an struct" → "a struct"

Old: Each instruction defines an struct with the accounts and parameters required.
New: Each instruction defines a struct with the accounts and parameters required.
Reason: "Struct" starts with a consonant sound, so the correct article is "a" instead of "an."
Files Modified: Multiple documentation files
Correction of "ouput" → "output"

Old: To ouput a formatted message:
New: To output a formatted message:
Reason: Typographical error; "ouput" is incorrect spelling.
Files Modified: Documentation
Correction of "maximim" → "maximum"

Old: For &str types, it is possible to specify a maximim length and a truncation strategy:
New: For &str types, it is possible to specify a maximum length and a truncation strategy:
Reason: "Maximim" is a spelling mistake; the correct word is "maximum."
Files Modified: Documentation