### PR TITLE
Fix a bug in TransferChecked cpi struct

### DIFF
--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -65,6 +65,6 @@ impl TransferChecked<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 10) },
         };
 
-        invoke_signed(&instruction, &[self.from, self.to, self.authority], signers)
+        invoke_signed(&instruction, &[self.from, self.mint, self.to, self.authority], signers)
     }
 }

--- a/programs/token/src/instructions/transfer_checked.rs
+++ b/programs/token/src/instructions/transfer_checked.rs
@@ -65,6 +65,10 @@ impl TransferChecked<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 10) },
         };
 
-        invoke_signed(&instruction, &[self.from, self.mint, self.to, self.authority], signers)
+        invoke_signed(
+            &instruction,
+            &[self.from, self.mint, self.to, self.authority],
+            signers,
+        )
     }
 }


### PR DESCRIPTION
For the `pinocchio_token` crate, the mint account_info is missing in the `invoke_signed` of `TransferChecked`.  This causes the CPI to fail. This PR adds the missing account_info to the `invoke_signed`.