### PR TITLE
ci: Add cargo registry token check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,6 @@ jobs:
         run: |
           pnpm semver ${{ inputs.crate }}
 
-
   publish_release:
     name: Publish
     runs-on: ubuntu-latest
@@ -111,6 +110,15 @@ jobs:
 
       - name: Test
         run: pnpm test ${{ inputs.crate }}
+
+      - name: Ensure CARGO_REGISTRY_TOKEN variable is set
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        if: ${{ env.CARGO_REGISTRY_TOKEN == '' }}
+        run: |
+          echo "The CARGO_REGISTRY_TOKEN secret variable is not set"
+          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+          exit 1
 
       - name: Set Git Author
         run: |


### PR DESCRIPTION
### Problem

Currently the publish workflow does not check if the cargo registry token is set.

### Solution

Add a step to check whether the cargo registry token is set or not.