### PR TITLE
Update README layout

### DIFF
--- a/programs/associated-token-account/README.md
+++ b/programs/associated-token-account/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <a href="https://github.com/anza-xyz/pinocchio">
-    <img alt="pinocchio" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100" />
-  </a>
+ <img alt="pinocchio-associated-token-account" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
 </p>
 <h3 align="center">
   <code>pinocchio-associated-token-account</code>
 </h3>
 <p align="center">
   <a href="https://crates.io/crates/pinocchio-associated-token-account"><img src="https://img.shields.io/crates/v/pinocchio-associated-token-account?logo=rust" /></a>
-  <a href="https://docs.rs/pinocchio-associated-token-account/latest/pinocchio_associated_token_account/"><img src="https://img.shields.io/docsrs/pinocchio-associated-token-account?logo=docsdotrs" /></a>
+  <a href="https://docs.rs/pinocchio-associated-token-account"><img src="https://img.shields.io/docsrs/pinocchio-associated-token-account?logo=docsdotrs" /></a>
 </p>
+
+## Overview
 
 This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for SPL Associated Token Account program instructions.
 

--- a/programs/system/README.md
+++ b/programs/system/README.md
@@ -1,4 +1,15 @@
-# <img width="250" alt="pinocchio-system" src="https://github.com/user-attachments/assets/6a775333-c3a1-4623-aa7a-afdc8c492594"/>
+<p align="center">
+ <img alt="pinocchio-system" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
+</p>
+<h3 align="center">
+  <code>pinocchio-system</code>
+</h3>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-system"><img src="https://img.shields.io/crates/v/pinocchio-system?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-system"><img src="https://img.shields.io/docsrs/pinocchio-system?logo=docsdotrs" /></a>
+</p>
+
+## Overview
 
 This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for System program instructions.
 

--- a/programs/token/README.md
+++ b/programs/token/README.md
@@ -1,4 +1,15 @@
-# <img width="229" alt="pinocchio-token" src="https://github.com/user-attachments/assets/12b0dc2a-94fb-4866-8e6a-60ac74e13b4f"/>
+<p align="center">
+ <img alt="pinocchio-token" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
+</p>
+<h3 align="center">
+  <code>pinocchio-token</code>
+</h3>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-token"><img src="https://img.shields.io/crates/v/pinocchio-token?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-token"><img src="https://img.shields.io/docsrs/pinocchio-token?logo=docsdotrs" /></a>
+</p>
+
+## Overview
 
 This crate contains [`pinocchio`](https://crates.io/crates/pinocchio) helpers to perform cross-program invocations (CPIs) for SPL Token instructions.
 

--- a/sdk/log/README.md
+++ b/sdk/log/README.md
@@ -1,14 +1,15 @@
-<h1 align="center">
-  <code>pinocchio-log</code>
-</h1>
 <p align="center">
- <img width="350" alt="pinocchio-log" src="https://github.com/user-attachments/assets/9b100f7c-216d-4849-b27d-3436f88af1bf"/>
+ <img alt="pinocchio-log" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
 </p>
+<h3 align="center">
+  <code>pinocchio-log</code>
+</h3>
 <p align="center">
  Lightweight log utility for Solana programs.
 </p>
 <p align="center">
   <a href="https://crates.io/crates/pinocchio-log"><img src="https://img.shields.io/crates/v/pinocchio-log?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-log"><img src="https://img.shields.io/docsrs/pinocchio-log?logo=docsdotrs" /></a>
 </p>
 
 ## Overview

--- a/sdk/log/macro/README.md
+++ b/sdk/log/macro/README.md
@@ -1,14 +1,15 @@
-<h1 align="center">
-  <code>pinocchio-log-macro</code>
-</h1>
 <p align="center">
- <img width="350" alt="pinocchio-log-macro" src="https://github.com/user-attachments/assets/9b100f7c-216d-4849-b27d-3436f88af1bf"/>
+ <img alt="pinocchio-log-macro" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
 </p>
+<h3 align="center">
+  <code>pinocchio-log-macro</code>
+</h3>
 <p align="center">
  Companion <code>log!</code> macro for <a href="https://crates.io/crates/pinocchio-log"><code>pinocchio-log</code></a>.
 </p>
 <p align="center">
   <a href="https://crates.io/crates/pinocchio-log-macro"><img src="https://img.shields.io/crates/v/pinocchio-log-macro?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-log-macro"><img src="https://img.shields.io/docsrs/pinocchio-log-macro?logo=docsdotrs" /></a>
 </p>
 
 ## Overview

--- a/sdk/pubkey/README.md
+++ b/sdk/pubkey/README.md
@@ -1,6 +1,18 @@
-# <img width="250" alt="pinocchio-pubkey" src="https://github.com/user-attachments/assets/de950d77-1f02-4d52-a2a8-fbf4029aa2dc"/>
+<p align="center">
+ <img alt="pinocchio-pubkey" src="https://github.com/user-attachments/assets/4048fe96-9096-4441-85c3-5deffeb089a6" height="100"/>
+</p>
+<h3 align="center">
+  <code>pinocchio-pubkey</code>
+</h3>
+<p align="center">
+ Companion <code>Pubkey</code> helpers for <a href="https://github.com/febo/pinocchio"><code>pinocchio</code></a>.
+</p>
+<p align="center">
+  <a href="https://crates.io/crates/pinocchio-pubkey"><img src="https://img.shields.io/crates/v/pinocchio-pubkey?logo=rust" /></a>
+  <a href="https://docs.rs/pinocchio-pubkey"><img src="https://img.shields.io/docsrs/pinocchio-pubkey?logo=docsdotrs" /></a>
+</p>
 
-Companion `Pubkey` helpers for [`pinocchio`](https://github.com/febo/pinocchio).
+## Overview
 
 This crate provides two convenience macros to resolve `Pubkey`s at compile time:
 

--- a/sdk/pubkey/README.md
+++ b/sdk/pubkey/README.md
@@ -5,7 +5,7 @@
   <code>pinocchio-pubkey</code>
 </h3>
 <p align="center">
- Companion <code>Pubkey</code> helpers for <a href="https://github.com/febo/pinocchio"><code>pinocchio</code></a>.
+ Companion <code>Pubkey</code> helpers for <a href="https://github.com/anza-xyz/pinocchio"><code>pinocchio</code></a>.
 </p>
 <p align="center">
   <a href="https://crates.io/crates/pinocchio-pubkey"><img src="https://img.shields.io/crates/v/pinocchio-pubkey?logo=rust" /></a>

--- a/sdk/pubkey/src/lib.rs
+++ b/sdk/pubkey/src/lib.rs
@@ -1,7 +1,7 @@
 pub use five8_const::decode_32_const;
 pub use pinocchio;
 
-// Convenience macro to define a static `Pubkey` value.
+/// Convenience macro to define a static `Pubkey` value.
 #[macro_export]
 macro_rules! pubkey {
     ( $id:literal ) => {
@@ -9,6 +9,10 @@ macro_rules! pubkey {
     };
 }
 
+/// Convenience macro to define a static `Pubkey` value representing the program ID.
+///
+/// This macro also defines a helper function to check whether a given pubkey is
+/// equal to the program ID.
 #[macro_export]
 macro_rules! declare_id {
     ( $id:expr ) => {
@@ -29,6 +33,7 @@ macro_rules! declare_id {
     };
 }
 
+/// Create a `Pubkey` from a `&str`.
 #[inline(always)]
 pub const fn from_str(value: &str) -> pinocchio::pubkey::Pubkey {
     decode_32_const(value)


### PR DESCRIPTION
### Problem

Currently each crate `README` follows a slightly different layout.

### Solution

This PR applied the same layout to all `README`s (apart from the main `pinocchio` crate).