### PR TITLE
ci: Add proc-macro test

### DIFF
--- a/scripts/semver.mts
+++ b/scripts/semver.mts
@@ -1,8 +1,17 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import { cliArguments, workingDirectory } from './setup/shared.mts';
+import { cliArguments, getCargo, workingDirectory } from './setup/shared.mts';
 
 const [folder, ...args] = cliArguments();
 const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 
-await $`cargo semver-checks --manifest-path ${manifestPath} ${args}`;
+const isProcMacro = getCargo(folder).lib['proc-macro'] === true;
+
+if (isProcMacro) {
+  echo(
+    chalk.yellow.bold('[ SKIPPED ]'),
+    'Proc-macro found: only library targets with API surface that can be checked for semver.'
+  );
+} else {
+  await $`cargo semver-checks --manifest-path ${manifestPath} ${args}`;
+}


### PR DESCRIPTION
### Problem

The publish workflow includes semver-checks to validate the version bump, but checks cannot be run on proc-macro crates.

### Solution

This PR adds a test on the semver-checks script to skip the check for proc-macro crates; a message is logged instead.