### PR TITLE
pubkey: Add `no_std` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,18 +13,18 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
 
 [[package]]
 name = "five8_core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a72055cd9cffc40c9f75f1e5810c80559e158796cf2202292ce4745889588"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 repository = "https://github.com/anza-xyz/pinocchio"
 
 [workspace.dependencies]
-five8_const = "0.1.3"
+five8_const = "0.1.4"
 pinocchio = { path = "sdk/pinocchio", version = "0.8" }
 pinocchio-pubkey = { path = "sdk/pubkey", version = "0.2" }
 pinocchio-log-macro = { version = "0.4", path = "sdk/log/macro" }

--- a/sdk/pubkey/src/lib.rs
+++ b/sdk/pubkey/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub use five8_const::decode_32_const;
 pub use pinocchio;
 


### PR DESCRIPTION
### Problem

Currently the `pinocchio-pubkey` crate is no_std "friendly" but does not include the no_std attribute, same as its current `five8_const` dependency. This brings the `std` during the link stage of the build.


### Solution

Add the no_std attribute and update `five8_const` dependency, which is also no_std now.