### PR TITLE
add dummy handler for non-solana target

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -293,6 +293,16 @@ macro_rules! nostd_panic_handler {
                 unsafe { $crate::syscalls::abort() }
             }
         }
+
+        /// A placeholder for `cargo clippy`
+        ///
+        /// Add `panic = "abort"` to `[profile.dev]` in `Cargo.toml` for clippy
+        #[cfg(not(target_os = "solana"))]
+        #[no_mangle]
+        #[panic_handler]
+        fn handler(info: &core::panic::PanicInfo<'_>) -> ! {
+            unsafe { core::hint::unreachable_unchecked() }
+        }
     };
 }
 


### PR DESCRIPTION
it's usual for rust devs to use `cargo clippy` or `cargo check`. when it's no_std, we need to specify the `panic_handler`