### PR TITLE
fix: use u64 prefix string instead of u32 prefix string

### DIFF
--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -49,17 +49,17 @@ impl AllocateWithSeed<'_, '_, '_> {
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..36 ]: base pubkey
-        // - [36..40]: seed length
-        // - [40..  ]: seed (max 32)
+        // - [36..44]: seed length
+        // - [44..  ]: seed (max 32)
         // - [..  +8]: account space
         // - [.. +32]: owner pubkey
         let mut instruction_data = [0; 112];
         instruction_data[0] = 9;
         instruction_data[4..36].copy_from_slice(self.base.key());
-        instruction_data[36..40].copy_from_slice(&u32::to_le_bytes(self.seed.len() as u32));
+        instruction_data[36..44].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
 
-        let offset = 40 + self.seed.len();
-        instruction_data[40..offset].copy_from_slice(self.seed.as_bytes());
+        let offset = 44 + self.seed.len();
+        instruction_data[44..offset].copy_from_slice(self.seed.as_bytes());
         instruction_data[offset..offset + 8].copy_from_slice(&self.space.to_le_bytes());
         instruction_data[offset + 8..offset + 40].copy_from_slice(self.owner.as_ref());
 

--- a/programs/system/src/instructions/assign_with_seed.rs
+++ b/programs/system/src/instructions/assign_with_seed.rs
@@ -45,16 +45,16 @@ impl AssignWithSeed<'_, '_, '_> {
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..36 ]: base pubkey
-        // - [36..40]: seed length
-        // - [40..  ]: seed (max 32)
+        // - [36..44]: seed length
+        // - [44..  ]: seed (max 32)
         // - [.. +32]: owner pubkey
         let mut instruction_data = [0; 104];
         instruction_data[0] = 10;
         instruction_data[4..36].copy_from_slice(self.base.key());
-        instruction_data[36..40].copy_from_slice(&u32::to_le_bytes(self.seed.len() as u32));
+        instruction_data[36..44].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
 
-        let offset = 40 + self.seed.len();
-        instruction_data[40..offset].copy_from_slice(self.seed.as_bytes());
+        let offset = 44 + self.seed.len();
+        instruction_data[44..offset].copy_from_slice(self.seed.as_bytes());
         instruction_data[offset..offset + 32].copy_from_slice(self.owner.as_ref());
 
         let instruction = Instruction {

--- a/programs/system/src/instructions/create_account_with_seed.rs
+++ b/programs/system/src/instructions/create_account_with_seed.rs
@@ -57,18 +57,18 @@ impl CreateAccountWithSeed<'_, '_, '_> {
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..36 ]: base pubkey
-        // - [36..40]: seed length
-        // - [40..  ]: seed (max 32)
+        // - [36..44]: seed length
+        // - [44..  ]: seed (max 32)
         // - [..  +8]: lamports
         // - [..  +8]: account space
         // - [.. +32]: owner pubkey
         let mut instruction_data = [0; 120];
         instruction_data[0] = 3;
         instruction_data[4..36].copy_from_slice(self.base.unwrap_or(self.from).key());
-        instruction_data[36..40].copy_from_slice(&u32::to_le_bytes(self.seed.len() as u32));
+        instruction_data[36..44].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
 
-        let offset = 40 + self.seed.len();
-        instruction_data[40..offset].copy_from_slice(self.seed.as_bytes());
+        let offset = 44 + self.seed.len();
+        instruction_data[44..offset].copy_from_slice(self.seed.as_bytes());
         instruction_data[offset..offset + 8].copy_from_slice(&self.lamports.to_le_bytes());
         instruction_data[offset + 8..offset + 16].copy_from_slice(&self.space.to_le_bytes());
         instruction_data[offset + 16..offset + 48].copy_from_slice(self.owner.as_ref());

--- a/programs/system/src/instructions/transfer_with_seed.rs
+++ b/programs/system/src/instructions/transfer_with_seed.rs
@@ -53,16 +53,16 @@ impl TransferWithSeed<'_, '_, '_> {
         // instruction data
         // - [0..4  ]: instruction discriminator
         // - [4..12 ]: lamports amount
-        // - [12..16]: seed length
-        // - [16..  ]: seed (max 32)
+        // - [12..20]: seed length
+        // - [20..  ]: seed (max 32)
         // - [.. +32]: owner pubkey
         let mut instruction_data = [0; 80];
         instruction_data[0] = 11;
         instruction_data[4..12].copy_from_slice(&self.lamports.to_le_bytes());
-        instruction_data[12..16].copy_from_slice(&u32::to_le_bytes(self.seed.len() as u32));
+        instruction_data[12..20].copy_from_slice(&u64::to_le_bytes(self.seed.len() as u64));
 
-        let offset = 16 + self.seed.len();
-        instruction_data[16..offset].copy_from_slice(self.seed.as_bytes());
+        let offset = 20 + self.seed.len();
+        instruction_data[20..offset].copy_from_slice(self.seed.as_bytes());
         instruction_data[offset..offset + 32].copy_from_slice(self.owner.as_ref());
 
         let instruction = Instruction {


### PR DESCRIPTION
the original `system-program` uses `u64` prefix string [idl](https://github.com/solana-program/system/blob/main/program/idl.json#L284)