### PR TITLE
Fix a bug with sol_get_processed_sibling_instructions syscall

### DIFF
--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -172,6 +172,12 @@ impl<'a> From<&'a AccountInfo> for AccountMeta<'a> {
 #[derive(Default, Debug, Clone, Copy)]
 pub struct RawAccountMeta(Pubkey, bool, bool);
 
+impl<'a> From<&'a RawAccountMeta> for AccountMeta<'a> {
+    fn from(value: &'a RawAccountMeta) -> Self {
+        AccountMeta::new(&value.0, value.1, value.2)
+    }
+}
+
 /// Represents a signer seed.
 ///
 /// This struct contains the same information as a `[u8]`, but

--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -164,6 +164,14 @@ impl<'a> From<&'a AccountInfo> for AccountMeta<'a> {
     }
 }
 
+/// This is a identical to AccountMeta, but with an owned Pubkey instead of a reference.
+/// For the sol_get_processed_sibling_instruction syscall, the syscall expects a pointer to an array
+/// of 34 bytes per account. The AccountMeta struct is only 16 bytes because of the use of a reference
+/// to the Pubkey. Other than the sol_get_processed_sibling_instruction syscall, AccountMeta shoudl be used.
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct RawAccountMeta(Pubkey, bool, bool);
+
 /// Represents a signer seed.
 ///
 /// This struct contains the same information as a `[u8]`, but

--- a/sdk/pinocchio/src/syscalls.rs
+++ b/sdk/pinocchio/src/syscalls.rs
@@ -1,7 +1,7 @@
 //! Syscall functions.
 
 use crate::{
-    instruction::{AccountMeta, ProcessedSiblingInstruction},
+    instruction::{RawAccountMeta, ProcessedSiblingInstruction},
     pubkey::Pubkey,
 };
 
@@ -63,7 +63,7 @@ define_syscall!(fn sol_invoke_signed_rust(instruction_addr: *const u8, account_i
 define_syscall!(fn sol_set_return_data(data: *const u8, length: u64));
 define_syscall!(fn sol_get_return_data(data: *mut u8, length: u64, program_id: *mut Pubkey) -> u64);
 define_syscall!(fn sol_log_data(data: *const u8, data_len: u64));
-define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut ProcessedSiblingInstruction, program_id: *mut Pubkey, data: *mut u8, accounts: *mut AccountMeta) -> u64);
+define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut ProcessedSiblingInstruction, program_id: *mut Pubkey, data: *mut u8, accounts: *mut RawAccountMeta) -> u64);
 define_syscall!(fn sol_get_stack_height() -> u64);
 define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);

--- a/sdk/pinocchio/src/syscalls.rs
+++ b/sdk/pinocchio/src/syscalls.rs
@@ -1,7 +1,7 @@
 //! Syscall functions.
 
 use crate::{
-    instruction::{RawAccountMeta, ProcessedSiblingInstruction},
+    instruction::{ProcessedSiblingInstruction, RawAccountMeta},
     pubkey::Pubkey,
 };
 


### PR DESCRIPTION
The sol_get_processed_sibling_instructions for the accounts parameter, expects a pointer to an array of AccountMeta (of 34 bytes each, Pubkey + 2x bool). The `AccountMeta` struct in Pinocchio has a reference to the Pubkey field instead of an owned version of the Pubkey. This results in the Pinocchio `AccountMeta` struct only being 16 bytes. The syscall fails because of this since it would try to write data beyond the data of the supplied ptr.

This PR adds a RawAccountMeta struct which has an owned version of Pubkey, is therefore 34 bytes long and will work with the syscall.

Other option that should be possible is just define the syscall with `*mut [u8]` instead of creating this extra struct but imo that makes the syscall more difficult to use (you need to figure out the bytes length yourself).

@febo lmk what you think!