### PR TITLE
Use `ProgramError` from Solana SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "pinocchio"
 version = "0.8.0"
+dependencies = [
+ "solana-program-error",
+]
 
 [[package]]
 name = "pinocchio-associated-token-account"
@@ -130,6 +133,11 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "solana-program-error"
+version = "2.2.1"
+source = "git+https://github.com/kevinheavey/solana-sdk.git?branch=program-error-pinocchio-compat#19430020ac0b45344a22dff070240dec4de818bf"
 
 [[package]]
 name = "syn"

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -17,4 +17,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [features]
-std = []
+std = ["solana-program-error/std"]
+
+[dependencies]
+solana-program-error = { version = "2.2.1", git = "https://github.com/kevinheavey/solana-sdk.git", branch = "program-error-pinocchio-compat" }

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -233,13 +233,13 @@ pub mod memory;
 pub mod program {
     pub use crate::cpi::*;
 }
-pub mod program_error;
 pub mod pubkey;
 pub mod syscalls;
 pub mod sysvars;
 
 #[deprecated(since = "0.7.0", note = "Use the `entrypoint` module instead")]
 pub use entrypoint::lazy as lazy_entrypoint;
+pub use solana_program_error as program_error;
 
 /// Maximum number of accounts that a transaction may process.
 ///


### PR DESCRIPTION
### Problem

Pinocchio currently re-implements the `ProgramError` type, which is essentially a copy of the same type from Solana SDK. This will make it awkward to write code that interact with both pinocchio and SDK types.

### Solution

Bring the `ProgramError` type from `solana-program-error` crate. This adds a dependency to pinocchio – an "internal" dependency to a SDK crate.