### PR TITLE
ci: Add changelog generation

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,0 +1,58 @@
+# git-cliff configuration file
+# https://git-cliff.org/docs/configuration
+#
+# Lines starting with "#" are comments.
+# Configuration options are organized into tables and keys.
+# See documentation for more information on available options.
+
+[changelog]
+header = """
+## What's new
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | split(pat="\n") | first | trim }}\
+        {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+    {% endfor %}\
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+footer = """
+"""
+postprocessors = [ ]
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = []
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^build\\(deps\\)", skip = true },
+    { message = "^build\\(deps-dev\\)", skip = true },
+    { message = "^ci", skip = true },
+    { body = ".*", group = "Changes" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"
+# limit the number of commits included in the changelog.
+# limit_commits = 42

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,8 +140,22 @@ jobs:
 
           pnpm tsx ./scripts/publish.mts ${{ inputs.crate }} $LEVEL $OPTIONS
 
+      - name: Generate a changelog
+        if: github.event.inputs.dry_run != 'true' && github.event.inputs.create_release == 'true'
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: ".github/cliff.toml"
+          args: |
+            "${{ steps.publish.outputs.old_git_tag }}"..main
+            --include-path "${{ inputs.crate }}/**"
+            --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create GitHub release
         if: github.event.inputs.dry_run != 'true' && github.event.inputs.create_release == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.publish.outputs.crate }}@v${{ steps.publish.outputs.version }}
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: CHANGELOG.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ build = "1.84.1"
 format = "nightly-2024-11-22"
 lint = "nightly-2024-11-22"
 test = "1.84.1"
+
+[workspace.metadata.release]
+pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
+tag-message = "Publish {{crate_name}} v{{version}}"
+consolidate-commits = false


### PR DESCRIPTION
### Problem

Currently when a crate is published, there is no option to automatically generate a changelog for the release.

### Solution

Add changelog generation using `git cliff` to the publish workflow.

Closes #57