### PR TITLE
publish: Add fetch depth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
### Problem

Currently the changelog generation is failing since it cannot find previous tags.

### Solution

Use the `fetch-depth` parameter on the Git checkout action to retrieve the whole history.