### PR TITLE
memo: Use local dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/anza-xyz/pinocchio"
 
 [workspace.dependencies]
 five8_const = "0.1.4"
-pinocchio = { path = "sdk/pinocchio", version = "0.8" }
-pinocchio-pubkey = { path = "sdk/pubkey", version = "0.2" }
+pinocchio = { version = "0.8", path = "sdk/pinocchio" }
 pinocchio-log-macro = { version = "0.4", path = "sdk/log/macro" }
+pinocchio-pubkey = { version = "0.2", path = "sdk/pubkey" }
 quote = "1.0"
 regex = "1"
 syn = "1.0"

--- a/programs/memo/Cargo.toml
+++ b/programs/memo/Cargo.toml
@@ -11,5 +11,5 @@ repository = { workspace = true }
 crate-type = ["rlib"]
 
 [dependencies]
-pinocchio = { workspace = true }
+pinocchio = { version = "0.8.1", path = "../../sdk/pinocchio" }
 pinocchio-pubkey = { workspace = true }


### PR DESCRIPTION
### Problem

The current `pinocchio` workspace dependency is set to `0.8`, but the `memo` crate requires `0.8.1`.

### Solution

Use a local version for the `pinocchio` dependency in the `memo` crate. We can switch back to use a workspace dependency in the next major bump.