### PR TITLE
log: Use alloc crate

### DIFF
--- a/sdk/log/macro/src/lib.rs
+++ b/sdk/log/macro/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{format, string::ToString, vec::Vec};
 use proc_macro::TokenStream;
 use quote::quote;
 use regex::Regex;


### PR DESCRIPTION
### Problem

Currently the macro in the `log` package is dependent on `std`, but it does not use anything specific from it.

### Solution

Use `alloc` instead and mark the macro as `no_std`.