### PR TITLE
add dummy allocator for clippy

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -318,6 +318,12 @@ macro_rules! default_allocator {
             start: $crate::entrypoint::HEAP_START_ADDRESS as usize,
             len: $crate::entrypoint::HEAP_LENGTH,
         };
+
+        // A placeholder for `cargo clippy`
+        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(feature = "std"))]
+        #[global_allocator]
+        static A: $crate::entrypoint::NoAllocator = $crate::entrypoint::NoAllocator;
     };
 }
 


### PR DESCRIPTION
similar to #104, if `alloc` is used, we need a dummy `global_allocator` for clippy