### PR TITLE
Add manual heap space allocation

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -360,19 +360,17 @@ macro_rules! no_allocator {
         #[inline]
         pub const unsafe fn allocate_unchecked<T: Sized>(offset: usize) -> &'static mut T {
             unsafe {
-                let start = $crate::entrypoint::HEAP_START_ADDRESS as usize
-                    + core::mem::size_of::<*mut u8>()
-                    + offset;
+                let start = $crate::entrypoint::HEAP_START_ADDRESS as usize + offset;
                 let end = start + core::mem::size_of::<T>();
 
-                // Assert that the allocation does not exceed the heap size.
+                // Assert if the allocation does not exceed the heap size.
                 assert!(
                     end <= $crate::entrypoint::HEAP_START_ADDRESS as usize
                         + $crate::entrypoint::HEAP_LENGTH,
                     "allocation exceeds heap size"
                 );
 
-                // Assert that the allocation is aligned to `T`.
+                // Assert if the pointer is aligned to `T`.
                 assert!(
                     start % core::mem::align_of::<T>() == 0,
                     "offset is not aligned"

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -344,6 +344,43 @@ macro_rules! no_allocator {
         #[cfg(target_os = "solana")]
         #[global_allocator]
         static A: $crate::entrypoint::NoAllocator = $crate::entrypoint::NoAllocator;
+
+        /// Allocates memory for the given type `T` at the specified offset in the
+        /// heap reserved address space.
+        ///
+        /// # Safety
+        ///
+        /// It is the caller's responsibility to ensure that the offset does not
+        /// overlap with previous allocations and that type `T` can hold the bit-pattern
+        /// `0` as a valid value.
+        ///
+        /// For types that cannot hold the bit-pattern `0` as a valid value, use
+        /// `core::mem::MaybeUninit<T>` to allocate memory for the type and
+        /// initialize it later.
+        #[inline]
+        pub const unsafe fn allocate_unchecked<T: Sized>(offset: usize) -> &'static mut T {
+            unsafe {
+                let start = $crate::entrypoint::HEAP_START_ADDRESS as usize
+                    + core::mem::size_of::<*mut u8>()
+                    + offset;
+                let end = start + core::mem::size_of::<T>();
+
+                // Assert that the allocation does not exceed the heap size.
+                assert!(
+                    end <= $crate::entrypoint::HEAP_START_ADDRESS as usize
+                        + $crate::entrypoint::HEAP_LENGTH,
+                    "allocation exceeds heap size"
+                );
+
+                // Assert that the allocation is aligned to `T`.
+                assert!(
+                    start % core::mem::align_of::<T>() == 0,
+                    "offset is not aligned"
+                );
+
+                &mut *(start as *mut T)
+            }
+        }
     };
 }
 


### PR DESCRIPTION
### Problem

All programs have access to a runtime heap, which (normally) is a `32KB` memory region starting at virtual address `0x300000000`.  When no global allocator is set (e.g., when using the `no_allocator!` macro) the heap region is still available to the program.

### Solution

Allow a program to "manually" allocate types to the heap reserved space. This offers a slightly more efficient way to use the heap space compared to using an allocator – e.g.,:
```rust
// manual allocation
let value = unsafe { crate::allocate_unchecked::<[u8; 10000]>(0) };

// boxed allocation (uses ~70 CUs more than the manual one)
let value = Box::new([0u8; 10000]);
```
The `allocate_unchecked` function is only available when the `no_allocator!` is used.

Since mutable references in constant functions is unstable on the platform-tools toolchain, the feature has to be enabled in `lib.rs`:
```rust
#![cfg_attr(target_os = "solana", feature(const_mut_refs))]
```