### PR TITLE
[WIP] add Mock Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,24 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "five8_const"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,56 +27,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
-name = "libc"
-version = "0.2.171"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pinocchio"
 version = "0.8.1"
-dependencies = [
- "parking_lot",
-]
 
 [[package]]
 name = "pinocchio-associated-token-account"
@@ -171,15 +111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,18 +140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "smallvec"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,67 +155,3 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "five8_const"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,14 +45,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pinocchio"
 version = "0.8.1"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "pinocchio-associated-token-account"
@@ -111,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,3 +236,67 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rand_core",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "five8_const"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,14 +129,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pinocchio"
 version = "0.8.1"
+dependencies = [
+ "solana-pubkey",
+]
 
 [[package]]
 name = "pinocchio-associated-token-account"
@@ -57,7 +255,7 @@ version = "0.4.0"
 dependencies = [
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -111,6 +309,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +353,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "solana-atomic-u64"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "solana-decode-error"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a6a6383af236708048f8bd8d03db8ca4ff7baf4a48e5d580f4cce545925470"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
+
+[[package]]
+name = "solana-hash"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7bcb14392900fe02e4e34e90234fbf0c673d4e327888410ba99fa2ba0f4e99"
+dependencies = [
+ "bs58",
+ "js-sys",
+ "solana-atomic-u64",
+ "solana-sanitize",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad77cf9f30b971a1eec48dde6a863dcac60ba005a34dfde23736afa5c7ac667"
+dependencies = [
+ "bs58",
+ "curve25519-dalek",
+ "five8_const",
+ "getrandom",
+ "js-sys",
+ "num-traits",
+ "solana-atomic-u64",
+ "solana-decode-error",
+ "solana-define-syscall",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-sanitize"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
+dependencies = [
+ "sha2",
+ "solana-define-syscall",
+ "solana-hash",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +488,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -16,9 +16,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_feature, values("static-syscalls"))',
 ] }
 
-[dependencies]
-parking_lot = { version = "0.12", optional = true }
-
 [features]
 std = []
-test = ["std", "parking_lot"]
+test = ["std"]

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -16,6 +16,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_feature, values("static-syscalls"))',
 ] }
 
+[dependencies]
+parking_lot = { version = "0.12", optional = true }
+
 [features]
 std = []
-test = ["std"]
+test = ["std", "parking_lot"]

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -18,3 +18,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [features]
 std = []
+test = ["std"]

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -16,6 +16,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_feature, values("static-syscalls"))',
 ] }
 
+[dependencies]
+solana-pubkey = { version = "2.3", features = ["curve25519"], optional = true }
+
 [features]
 std = []
-test = ["std"]
+test = ["std", "solana-pubkey"]

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -235,6 +235,7 @@ pub mod program {
 }
 pub mod program_error;
 pub mod pubkey;
+pub mod runtime;
 pub mod syscalls;
 pub mod sysvars;
 

--- a/sdk/pinocchio/src/runtime/blackbox.rs
+++ b/sdk/pinocchio/src/runtime/blackbox.rs
@@ -53,4 +53,12 @@ impl Runtime for BlackBoxRuntime {
         core::hint::black_box((instruction, account_infos, signers_seeds));
         Ok(())
     }
+
+    fn sol_create_program_address(
+        seeds: &[&[u8]],
+        program_id: &crate::pubkey::Pubkey,
+    ) -> Result<crate::pubkey::Pubkey, crate::program_error::ProgramError> {
+        core::hint::black_box((seeds, program_id));
+        panic!("create_program_address is only available on target `solana`")
+    }
 }

--- a/sdk/pinocchio/src/runtime/blackbox.rs
+++ b/sdk/pinocchio/src/runtime/blackbox.rs
@@ -1,0 +1,56 @@
+use super::Runtime;
+
+pub struct BlackBoxRuntime;
+
+impl Runtime for BlackBoxRuntime {
+    fn sol_log(message: &str) {
+        core::hint::black_box(message);
+    }
+
+    fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+        core::hint::black_box((arg1, arg2, arg3, arg4, arg5));
+    }
+
+    fn sol_log_data(data: &[&[u8]]) {
+        core::hint::black_box(data);
+    }
+
+    fn sol_log_compute_units() {
+        core::hint::black_box(());
+    }
+
+    unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
+        core::hint::black_box((dst, src, n));
+    }
+
+    unsafe fn sol_memmove(dst: *mut u8, src: *mut u8, n: usize) {
+        core::hint::black_box((dst, src, n));
+    }
+
+    unsafe fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
+        core::hint::black_box((s1, s2, n));
+        0
+    }
+
+    unsafe fn sol_memset(s: &mut [u8], c: u8, n: usize) {
+        core::hint::black_box((s, c, n));
+    }
+
+    fn invoke_signed<const ACCOUNTS: usize>(
+        instruction: &crate::instruction::Instruction,
+        account_infos: &[&crate::account_info::AccountInfo; ACCOUNTS],
+        signers_seeds: &[crate::instruction::Signer],
+    ) -> crate::ProgramResult {
+        core::hint::black_box((instruction, account_infos, signers_seeds));
+        Ok(())
+    }
+
+    unsafe fn invoke_signed_access_unchecked<const ACCOUNTS: usize>(
+        instruction: &crate::instruction::Instruction,
+        account_infos: &[&crate::account_info::AccountInfo; ACCOUNTS],
+        signers_seeds: &[crate::instruction::Signer],
+    ) -> crate::ProgramResult {
+        core::hint::black_box((instruction, account_infos, signers_seeds));
+        Ok(())
+    }
+}

--- a/sdk/pinocchio/src/runtime/mock.rs
+++ b/sdk/pinocchio/src/runtime/mock.rs
@@ -199,4 +199,22 @@ impl Runtime for MockRuntime {
 
         Ok(())
     }
+
+    fn sol_create_program_address(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> Result<Pubkey, ProgramError> {
+        solana_pubkey::Pubkey::create_program_address(
+            seeds,
+            &solana_pubkey::Pubkey::new_from_array(*program_id),
+        )
+        .map(|key| key.to_bytes())
+        .map_err(|err| match err {
+            solana_pubkey::PubkeyError::MaxSeedLengthExceeded => {
+                ProgramError::MaxSeedLengthExceeded
+            }
+            solana_pubkey::PubkeyError::InvalidSeeds => ProgramError::InvalidSeeds,
+            solana_pubkey::PubkeyError::IllegalOwner => ProgramError::IllegalOwner,
+        })
+    }
 }

--- a/sdk/pinocchio/src/runtime/mock.rs
+++ b/sdk/pinocchio/src/runtime/mock.rs
@@ -1,0 +1,53 @@
+use std::{
+    format,
+    string::String,
+    sync::{LazyLock, Mutex},
+    vec::Vec,
+};
+
+use super::Runtime;
+
+pub static MOCK_RUNTIME: LazyLock<Mutex<MockRuntime>> =
+    LazyLock::new(|| Mutex::new(MockRuntime::init()));
+
+pub struct MockRuntime {
+    logs: Vec<String>,
+    compute_units: u64,
+}
+
+impl MockRuntime {
+    pub fn init() -> Self {
+        MockRuntime {
+            logs: Vec::new(),
+            compute_units: 0,
+        }
+    }
+}
+
+impl Runtime for MockRuntime {
+    fn sol_log(message: &str) {
+        MOCK_RUNTIME.lock().unwrap().logs.push(message.into());
+    }
+
+    fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+        let mut rt = MOCK_RUNTIME.lock().unwrap();
+        rt.logs.push(format!(
+            "Program log: {:x} {:x} {:x} {:x} {:x}",
+            arg1, arg2, arg3, arg4, arg5
+        ));
+    }
+
+    fn sol_log_data(data: &[&[u8]]) {
+        MOCK_RUNTIME
+            .lock()
+            .unwrap()
+            .logs
+            .push(format!("data: {:?}", data));
+    }
+
+    fn sol_log_compute_units() {
+        let mut rt = MOCK_RUNTIME.lock().unwrap();
+        let cu = rt.compute_units;
+        rt.logs.push(format!("cu: {}", cu));
+    }
+}

--- a/sdk/pinocchio/src/runtime/mock.rs
+++ b/sdk/pinocchio/src/runtime/mock.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    format,
+    eprintln, format,
     string::String,
     sync::{Arc, LazyLock, Mutex},
     vec::Vec,
@@ -80,6 +80,13 @@ pub fn invoke<const ACCOUNTS: usize>(
         accounts.as_slice(),
         instruction.data,
     )
+    .map_err(|err| {
+        eprintln!("Err: {:?}", err);
+        eprintln!("---- LOG ----");
+        for log in MOCK_RUNTIME.lock().unwrap().logs.iter() {
+            eprintln!("{}", log);
+        }
+    })
     .expect("program failed to execute");
 }
 

--- a/sdk/pinocchio/src/runtime/mock.rs
+++ b/sdk/pinocchio/src/runtime/mock.rs
@@ -21,9 +21,9 @@ pub static MOCK_RUNTIME: LazyLock<Mutex<MockRuntime>> =
     LazyLock::new(|| Mutex::new(MockRuntime::init()));
 
 pub struct MockAccount {
-    key: Pubkey,
-    _lamports: u64,
-    data: MockData,
+    pub key: Pubkey,
+    pub lamports: u64,
+    pub data: MockData,
 }
 
 pub enum MockData {

--- a/sdk/pinocchio/src/runtime/mock.rs
+++ b/sdk/pinocchio/src/runtime/mock.rs
@@ -1,8 +1,18 @@
 use std::{
+    boxed::Box,
+    collections::HashMap,
     format,
     string::String,
     sync::{LazyLock, Mutex},
     vec::Vec,
+};
+
+use crate::{
+    account_info::AccountInfo,
+    instruction::{Instruction, Signer},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    ProgramResult,
 };
 
 use super::Runtime;
@@ -10,7 +20,19 @@ use super::Runtime;
 pub static MOCK_RUNTIME: LazyLock<Mutex<MockRuntime>> =
     LazyLock::new(|| Mutex::new(MockRuntime::init()));
 
+pub struct MockAccount {
+    key: Pubkey,
+    _lamports: u64,
+    data: MockData,
+}
+
+pub enum MockData {
+    Bytes(Vec<u8>),
+    Program(Box<dyn Fn(&Pubkey, &[AccountInfo], &[u8]) -> ProgramResult + Send>),
+}
+
 pub struct MockRuntime {
+    accounts: HashMap<Pubkey, MockAccount>,
     logs: Vec<String>,
     compute_units: u64,
 }
@@ -18,13 +40,49 @@ pub struct MockRuntime {
 impl MockRuntime {
     pub fn init() -> Self {
         MockRuntime {
+            accounts: HashMap::new(),
             logs: Vec::new(),
             compute_units: 0,
         }
     }
+
+    pub fn add_program(&mut self, program: MockAccount) {
+        let MockData::Program(_) = program.data else {
+            panic!("invalid MockAccount")
+        };
+        self.accounts.insert(program.key, program);
+    }
+
+    pub fn invoke<const ACCOUNTS: usize>(
+        &self,
+        instruction: &Instruction,
+        account_infos: &[&AccountInfo; ACCOUNTS],
+    ) {
+        let program = self
+            .accounts
+            .get(instruction.program_id)
+            .expect("program not found");
+
+        let MockData::Program(ref program) = program.data else {
+            panic!("invalid program id")
+        };
+
+        let accounts: Vec<_> = account_infos.iter().map(|acc| (*acc).clone()).collect();
+
+        program(
+            instruction.program_id,
+            accounts.as_slice(),
+            instruction.data,
+        )
+        .expect("program failed to execute");
+    }
 }
 
 impl Runtime for MockRuntime {
+    ////////////////////////////////////////////////////////////////////////////
+    // LOG SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
     fn sol_log(message: &str) {
         MOCK_RUNTIME.lock().unwrap().logs.push(message.into());
     }
@@ -49,5 +107,88 @@ impl Runtime for MockRuntime {
         let mut rt = MOCK_RUNTIME.lock().unwrap();
         let cu = rt.compute_units;
         rt.logs.push(format!("cu: {}", cu));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // MEM SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    unsafe fn sol_memcpy(_dst: &mut [u8], _src: &[u8], _n: usize) {
+        unimplemented!()
+    }
+
+    unsafe fn sol_memmove(_dst: *mut u8, _src: *mut u8, _n: usize) {
+        unimplemented!()
+    }
+
+    unsafe fn sol_memcmp(_s1: &[u8], _s2: &[u8], _n: usize) -> i32 {
+        unimplemented!()
+    }
+
+    unsafe fn sol_memset(_s: &mut [u8], _c: u8, _n: usize) {
+        unimplemented!()
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // CPI CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    fn invoke_signed<const ACCOUNTS: usize>(
+        instruction: &Instruction,
+        account_infos: &[&AccountInfo; ACCOUNTS],
+        _signers_seeds: &[Signer],
+    ) -> ProgramResult {
+        if instruction.accounts.len() < ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        for index in 0..ACCOUNTS {
+            let account_info = account_infos[index];
+            let account_meta = &instruction.accounts[index];
+
+            if account_info.key() != account_meta.pubkey {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            if account_meta.is_writable {
+                account_info.check_borrow_mut_data()?;
+                account_info.check_borrow_mut_lamports()?;
+            } else {
+                account_info.check_borrow_data()?;
+                account_info.check_borrow_lamports()?;
+            }
+        }
+
+        MOCK_RUNTIME
+            .lock()
+            .unwrap()
+            .invoke(instruction, account_infos);
+
+        Ok(())
+    }
+
+    unsafe fn invoke_signed_access_unchecked<const ACCOUNTS: usize>(
+        instruction: &Instruction,
+        account_infos: &[&AccountInfo; ACCOUNTS],
+        _signers_seeds: &[Signer],
+    ) -> ProgramResult {
+        if instruction.accounts.len() < ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        for index in 0..ACCOUNTS {
+            let account_info = account_infos[index];
+            let account_meta = &instruction.accounts[index];
+            if account_info.key() != account_meta.pubkey {
+                return Err(ProgramError::InvalidArgument);
+            }
+        }
+
+        MOCK_RUNTIME
+            .lock()
+            .unwrap()
+            .invoke(instruction, account_infos);
+
+        Ok(())
     }
 }

--- a/sdk/pinocchio/src/runtime/mod.rs
+++ b/sdk/pinocchio/src/runtime/mod.rs
@@ -10,7 +10,10 @@ use solana::SolanaRuntime;
 use crate::{
     account_info::AccountInfo,
     instruction::{Instruction, Signer},
-    msg, pubkey, ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::{self, Pubkey},
+    ProgramResult,
 };
 
 #[cfg(all(not(target_os = "solana"), not(feature = "test")))]
@@ -125,4 +128,13 @@ pub trait Runtime {
         account_infos: &[&AccountInfo; ACCOUNTS],
         signers_seeds: &[Signer],
     ) -> ProgramResult;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Addressing CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    fn sol_create_program_address(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> Result<Pubkey, ProgramError>;
 }

--- a/sdk/pinocchio/src/runtime/mod.rs
+++ b/sdk/pinocchio/src/runtime/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(all(not(target_os = "solana"), not(feature = "test")))]
 use blackbox::BlackBoxRuntime;
+
 #[cfg(all(not(target_os = "solana"), feature = "test"))]
 use mock::MockRuntime;
+
 #[cfg(target_os = "solana")]
 use solana::SolanaRuntime;
 
@@ -11,8 +13,13 @@ use crate::{
     msg, pubkey, ProgramResult,
 };
 
+#[cfg(all(not(target_os = "solana"), not(feature = "test")))]
 mod blackbox;
+
+#[cfg(all(not(target_os = "solana"), feature = "test"))]
 pub mod mock;
+
+#[cfg(target_os = "solana")]
 mod solana;
 
 #[cfg(target_os = "solana")]

--- a/sdk/pinocchio/src/runtime/mod.rs
+++ b/sdk/pinocchio/src/runtime/mod.rs
@@ -1,0 +1,68 @@
+#[cfg(not(target_os = "solana"))]
+use mock::MockRuntime;
+#[cfg(target_os = "solana")]
+use solana::SolanaRuntime;
+
+use crate::{account_info::AccountInfo, msg, pubkey};
+
+pub mod mock;
+pub mod solana;
+
+#[cfg(target_os = "solana")]
+pub type TargetRuntime = SolanaRuntime;
+
+#[cfg(not(target_os = "solana"))]
+pub type TargetRuntime = MockRuntime;
+
+pub trait Runtime {
+    ////////////////////////////////////////////////////////////////////////////
+    // LOG SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Print a string to the log.
+    fn sol_log(message: &str);
+
+    /// Print 64-bit values represented as hexadecimal to the log.
+    fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
+
+    /// Print some slices as base64.
+    fn sol_log_data(data: &[&[u8]]);
+
+    /// Print the hexadecimal representation of a slice.
+    fn sol_log_slice(slice: &[u8]) {
+        for (i, s) in slice.iter().enumerate() {
+            Self::sol_log_64(0, 0, 0, i as u64, *s as u64);
+        }
+    }
+
+    /// Print the hexadecimal representation of the program's input parameters.
+    ///
+    /// - `accounts` - A slice of [`AccountInfo`].
+    /// - `data` - The instruction data.
+    fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
+        for (i, account) in accounts.iter().enumerate() {
+            msg!("AccountInfo");
+            Self::sol_log_64(0, 0, 0, 0, i as u64);
+            msg!("- Is signer");
+            Self::sol_log_64(0, 0, 0, 0, account.is_signer() as u64);
+            msg!("- Key");
+            pubkey::log(account.key());
+            msg!("- Lamports");
+            Self::sol_log_64(0, 0, 0, 0, account.lamports());
+            msg!("- Account data length");
+            Self::sol_log_64(0, 0, 0, 0, account.data_len() as u64);
+            msg!("- Owner");
+            // SAFETY: The `owner` reference is only used for logging.
+            pubkey::log(unsafe { account.owner() });
+        }
+        msg!("Instruction data");
+        Self::sol_log_slice(data);
+    }
+
+    /// Print the remaining compute units available to the program.
+    fn sol_log_compute_units();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // MEM SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+}

--- a/sdk/pinocchio/src/runtime/solana.rs
+++ b/sdk/pinocchio/src/runtime/solana.rs
@@ -1,0 +1,29 @@
+use super::Runtime;
+
+pub struct SolanaRuntime;
+
+impl Runtime for SolanaRuntime {
+    fn sol_log(message: &str) {
+        unsafe {
+            crate::syscalls::sol_log_(message.as_ptr(), message.len() as u64);
+        }
+    }
+
+    fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+        unsafe {
+            crate::syscalls::sol_log_64_(arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
+    fn sol_log_data(data: &[&[u8]]) {
+        unsafe {
+            crate::syscalls::sol_log_data(data as *const _ as *const u8, data.len() as u64);
+        };
+    }
+
+    fn sol_log_compute_units() {
+        unsafe {
+            crate::syscalls::sol_log_compute_units_();
+        }
+    }
+}

--- a/sdk/pinocchio/src/runtime/solana.rs
+++ b/sdk/pinocchio/src/runtime/solana.rs
@@ -1,8 +1,18 @@
+use core::mem::MaybeUninit;
+
+use crate::{
+    cpi::invoke_signed_unchecked, instruction::Account, program_error::ProgramError, syscalls,
+};
+
 use super::Runtime;
 
 pub struct SolanaRuntime;
 
 impl Runtime for SolanaRuntime {
+    ////////////////////////////////////////////////////////////////////////////
+    // LOG SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
     fn sol_log(message: &str) {
         unsafe {
             crate::syscalls::sol_log_(message.as_ptr(), message.len() as u64);
@@ -25,5 +35,107 @@ impl Runtime for SolanaRuntime {
         unsafe {
             crate::syscalls::sol_log_compute_units_();
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // MEM SYS CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
+        syscalls::sol_memcpy_(dst.as_mut_ptr(), src.as_ptr(), n as u64);
+    }
+
+    unsafe fn sol_memmove(dst: *mut u8, src: *mut u8, n: usize) {
+        syscalls::sol_memmove_(dst, src, n as u64);
+    }
+
+    unsafe fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
+        let mut result = 0;
+        syscalls::sol_memcmp_(s1.as_ptr(), s2.as_ptr(), n as u64, &mut result as *mut i32);
+        result
+    }
+
+    unsafe fn sol_memset(s: &mut [u8], c: u8, n: usize) {
+        syscalls::sol_memset_(s.as_mut_ptr(), c, n as u64);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // CPI CALLS
+    ////////////////////////////////////////////////////////////////////////////
+
+    fn invoke_signed<const ACCOUNTS: usize>(
+        instruction: &crate::instruction::Instruction,
+        account_infos: &[&crate::account_info::AccountInfo; ACCOUNTS],
+        signers_seeds: &[crate::instruction::Signer],
+    ) -> crate::ProgramResult {
+        if instruction.accounts.len() < ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        const UNINIT: MaybeUninit<Account> = MaybeUninit::<Account>::uninit();
+        let mut accounts = [UNINIT; ACCOUNTS];
+
+        for index in 0..ACCOUNTS {
+            let account_info = account_infos[index];
+            let account_meta = &instruction.accounts[index];
+
+            if account_info.key() != account_meta.pubkey {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            if account_meta.is_writable {
+                account_info.check_borrow_mut_data()?;
+                account_info.check_borrow_mut_lamports()?;
+            } else {
+                account_info.check_borrow_data()?;
+                account_info.check_borrow_lamports()?;
+            }
+
+            accounts[index].write(Account::from(account_infos[index]));
+        }
+
+        unsafe {
+            invoke_signed_unchecked(
+                instruction,
+                core::slice::from_raw_parts(accounts.as_ptr() as _, ACCOUNTS),
+                signers_seeds,
+            );
+        }
+
+        Ok(())
+    }
+
+    unsafe fn invoke_signed_access_unchecked<const ACCOUNTS: usize>(
+        instruction: &crate::instruction::Instruction,
+        account_infos: &[&crate::account_info::AccountInfo; ACCOUNTS],
+        signers_seeds: &[crate::instruction::Signer],
+    ) -> crate::ProgramResult {
+        if instruction.accounts.len() < ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        const UNINIT: MaybeUninit<Account> = MaybeUninit::<Account>::uninit();
+        let mut accounts = [UNINIT; ACCOUNTS];
+
+        for index in 0..ACCOUNTS {
+            let account_info = account_infos[index];
+            let account_meta = &instruction.accounts[index];
+
+            if account_info.key() != account_meta.pubkey {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            accounts[index].write(Account::from(account_infos[index]));
+        }
+
+        unsafe {
+            invoke_signed_unchecked(
+                instruction,
+                core::slice::from_raw_parts(accounts.as_ptr() as _, ACCOUNTS),
+                signers_seeds,
+            );
+        }
+
+        Ok(())
     }
 }

--- a/sdk/pinocchio/src/runtime/solana.rs
+++ b/sdk/pinocchio/src/runtime/solana.rs
@@ -138,4 +138,27 @@ impl Runtime for SolanaRuntime {
 
         Ok(())
     }
+
+    fn sol_create_program_address(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> Result<Pubkey, ProgramError> {
+        // Call via a system call to perform the calculation
+        let mut bytes = core::mem::MaybeUninit::<[u8; PUBKEY_BYTES]>::uninit();
+
+        let result = unsafe {
+            crate::syscalls::sol_create_program_address(
+                seeds as *const _ as *const u8,
+                seeds.len() as u64,
+                program_id as *const _ as *const u8,
+                bytes.as_mut_ptr() as *mut u8,
+            )
+        };
+
+        match result {
+            // SAFETY: The syscall has initialized the bytes.
+            crate::SUCCESS => Ok(unsafe { bytes.assume_init() }),
+            _ => Err(result.into()),
+        }
+    }
 }


### PR DESCRIPTION
Adds a Runtime trait to ensure all runtime implementations expose the same functionality. This is a sample PR to showcase what a possible solution could look like.

The idea here is to provide a mock environment for testing so you don’t need to spin up a local node. Useful for fast iteration, CI, and writing focused unit tests without going full integration.