### PR TITLE
Clean up unnecessary unsafe

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -365,25 +365,23 @@ macro_rules! no_allocator {
         /// initialize it later.
         #[inline]
         pub const unsafe fn allocate_unchecked<T: Sized>(offset: usize) -> &'static mut T {
-            unsafe {
-                let start = $crate::entrypoint::HEAP_START_ADDRESS as usize + offset;
-                let end = start + core::mem::size_of::<T>();
+            let start = $crate::entrypoint::HEAP_START_ADDRESS as usize + offset;
+            let end = start + core::mem::size_of::<T>();
 
-                // Assert if the allocation does not exceed the heap size.
-                assert!(
-                    end <= $crate::entrypoint::HEAP_START_ADDRESS as usize
-                        + $crate::entrypoint::HEAP_LENGTH,
-                    "allocation exceeds heap size"
-                );
+            // Assert if the allocation does not exceed the heap size.
+            assert!(
+                end <= $crate::entrypoint::HEAP_START_ADDRESS as usize
+                    + $crate::entrypoint::HEAP_LENGTH,
+                "allocation exceeds heap size"
+            );
 
-                // Assert if the pointer is aligned to `T`.
-                assert!(
-                    start % core::mem::align_of::<T>() == 0,
-                    "offset is not aligned"
-                );
+            // Assert if the pointer is aligned to `T`.
+            assert!(
+                start % core::mem::align_of::<T>() == 0,
+                "offset is not aligned"
+            );
 
-                &mut *(start as *mut T)
-            }
+            &mut *(start as *mut T)
         }
     };
 }

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -381,6 +381,7 @@ macro_rules! no_allocator {
                 "offset is not aligned"
             );
 
+            // SAFETY: The pointer is within a valid range and aligned to `T`.
             unsafe { &mut *(start as *mut T) }
         }
     };

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -381,7 +381,7 @@ macro_rules! no_allocator {
                 "offset is not aligned"
             );
 
-            &mut *(start as *mut T)
+            unsafe { &mut *(start as *mut T) }
         }
     };
 }


### PR DESCRIPTION
### Problem

There is an unnecessary double "unsafe" in `allocate_unchecked`.

### Solution

Remove the extra "unsafe".