### PR TITLE
Add rust version to crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/anza-xyz/pinocchio"
+rust-version = "1.79"
 
 [workspace.dependencies]
 five8_const = "0.1.4"

--- a/programs/associated-token-account/Cargo.toml
+++ b/programs/associated-token-account/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/programs/memo/Cargo.toml
+++ b/programs/memo/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/sdk/log/crate/Cargo.toml
+++ b/sdk/log/crate/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/sdk/log/macro/Cargo.toml
+++ b/sdk/log/macro/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/sdk/pinocchio/Cargo.toml
+++ b/sdk/pinocchio/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/sdk/pubkey/Cargo.toml
+++ b/sdk/pubkey/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
### Problem

Currently, crates in the workspace do not specify their minimum supported rust version. This could create issues when the rust version of platform-tools is updated and crates start using new features.

### Solution

Add the `rust-version` to the package information on `Cargo.toml` files. This way a crate can explicitly specify their minimum requirement.