### PR TITLE
fix: file extensions in package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "private": true,
   "scripts": {
-    "cargo-audit": "tsx ./scripts/audit.mjs",
-    "build-sbf": "tsx ./scripts/build-sbf.mjs",
-    "clippy": "tsx ./scripts/clippy.mjs",
-    "doc": "tsx ./scripts/doc.mjs",
-    "format": "tsx ./scripts/format.mjs",
-    "hack": "tsx ./scripts/hack.mjs",
-    "lint": "tsx ./scripts/lint.mjs",
-    "semver": "tsx ./scripts/semver.mjs",
-    "test": "tsx ./scripts/test.mjs"
+    "cargo-audit": "tsx ./scripts/audit.mts",
+    "build-sbf": "tsx ./scripts/build-sbf.mts",
+    "clippy": "tsx ./scripts/clippy.mts",
+    "doc": "tsx ./scripts/doc.mts",
+    "format": "tsx ./scripts/format.mts",
+    "hack": "tsx ./scripts/hack.mts",
+    "lint": "tsx ./scripts/lint.mts",
+    "semver": "tsx ./scripts/semver.mts",
+    "test": "tsx ./scripts/test.mts"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
changed `.mjs` -> `.mts` extensions in the `scripts` section of the root `package.json`.

everything works in the same way as before.
just a small niceness