### PR TITLE
add `copy_val` helper

### DIFF
--- a/sdk/pinocchio/src/memory.rs
+++ b/sdk/pinocchio/src/memory.rs
@@ -43,6 +43,19 @@ pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
 
 /// Copies the contents of one value to another.
 ///
+/// Equivalent to `dst = src` where `dst` and `src`
+/// are of same type and `impl Copy`.
+///
+/// This helper will be useful to optimize CU if
+/// copied size is > 32 bytes.
+///
+/// For value smaller than 32 bytes, `dst = src`
+/// will be emitted to register assignment. For
+/// values larger than 32 bytes, compiler will
+/// generate excess boilerplate to `sol_memcpy_`.
+/// So if T's size is known to be > 32 bytes,
+/// this helper should be used.
+///
 /// # Arguments
 ///
 /// - `dst` - Destination reference to copy to

--- a/sdk/pinocchio/src/memory.rs
+++ b/sdk/pinocchio/src/memory.rs
@@ -48,7 +48,7 @@ pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
 /// - `dst` - Destination reference to copy to
 /// - `src` - Source reference to copy from
 #[inline]
-pub fn copy_val<T: Sized>(dst: &mut T, src: &T) {
+pub fn copy_val<T: ?Sized>(dst: &mut T, src: &T) {
     #[cfg(target_os = "solana")]
     unsafe {
         syscalls::sol_memcpy_(

--- a/sdk/pinocchio/src/memory.rs
+++ b/sdk/pinocchio/src/memory.rs
@@ -50,6 +50,7 @@ pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
 #[inline]
 pub fn copy_val<T: ?Sized>(dst: &mut T, src: &T) {
     #[cfg(target_os = "solana")]
+    // SAFETY: dst and src are of same type therefore the size is the same
     unsafe {
         syscalls::sol_memcpy_(
             dst as *mut T as *mut u8,

--- a/sdk/pinocchio/src/memory.rs
+++ b/sdk/pinocchio/src/memory.rs
@@ -41,6 +41,12 @@ pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
     core::hint::black_box((dst, src, n));
 }
 
+/// Copies the contents of one value to another.
+///
+/// # Arguments
+///
+/// - `dst` - Destination reference to copy to
+/// - `src` - Source reference to copy from
 #[inline]
 pub fn copy_val<T: Sized>(dst: &mut T, src: &T) {
     #[cfg(target_os = "solana")]

--- a/sdk/pinocchio/src/memory.rs
+++ b/sdk/pinocchio/src/memory.rs
@@ -41,6 +41,21 @@ pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
     core::hint::black_box((dst, src, n));
 }
 
+#[inline]
+pub fn copy_val<T: Sized>(dst: &mut T, src: &T) {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        syscalls::sol_memcpy_(
+            dst as *mut T as *mut u8,
+            src as *const T as *const u8,
+            core::mem::size_of_val(dst) as u64,
+        );
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    core::hint::black_box((dst, src));
+}
+
 /// Like C `memmove`.
 ///
 /// # Arguments


### PR DESCRIPTION
`sol_memcpy_` is not really exposed well. this pr adds a helper function to call `sol_memcpy_` more easily.

since the size of T is known at compile time, it seems that we can decide to use direct assign or memcpy at 0 cost.

yet comparison between `memcpy` and directly assign is hard, because the content really affects the outcome. for a u64 (or any value that can fit into one register), `memcpy` will cost 13 more cu. i think we can live with that atm.