### PR TITLE
Relax rent sysvar length check

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -40,8 +40,8 @@ pub const SUCCESS: u64 = super::SUCCESS;
 /// provided function to process the program instruction supplied by the runtime, and reporting
 /// its result to the runtime.
 ///
-/// It also sets up a [global allocator] and [panic handler], using the [`crate::default_allocator!`]
-/// and [`crate::default_panic_handler!`] macros.
+/// It also sets up a [global allocator] and [panic handler], using the [`crate::default_allocator`]
+/// and [`crate::default_panic_handler`] macros.
 ///
 /// The first argument is the name of a function with this type signature:
 ///

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -40,8 +40,8 @@ pub const SUCCESS: u64 = super::SUCCESS;
 /// provided function to process the program instruction supplied by the runtime, and reporting
 /// its result to the runtime.
 ///
-/// It also sets up a [global allocator] and [panic handler], using the [`crate::default_allocator`]
-/// and [`crate::default_panic_handler`] macros.
+/// It also sets up a [global allocator] and [panic handler], using the [`crate::default_allocator!`]
+/// and [`crate::default_panic_handler!`] macros.
 ///
 /// The first argument is the name of a function with this type signature:
 ///

--- a/sdk/pinocchio/src/sysvars/rent.rs
+++ b/sdk/pinocchio/src/sysvars/rent.rs
@@ -108,9 +108,11 @@ impl Rent {
     /// a valid representation of `Rent`.
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Result<&Self, ProgramError> {
-        if bytes.len() != Self::LEN {
+        if bytes.len() < Self::LEN {
             return Err(ProgramError::InvalidArgument);
         }
+        // SAFETY: `bytes` has been validated to be at least `Self::LEN` bytes long; the
+        // caller must ensure that `bytes` contains a valid representation of `Rent`.
         Ok(unsafe { Self::from_bytes_unchecked(bytes) })
     }
 


### PR DESCRIPTION
### Problem

Currently the `Rent` sysvar  length validation is very strict – it requires the length of the byte buffer to be exactly the size of the type. This creates problems when running fuzzing tests since the sysvar account in some cases is bigger than the type.

### Solution

Relax the length test to require a minimum length instead. This PR also avoids initializing the byte buffer passed to the syscall, which saves CUs.