### PR TITLE
Use static syscalls when available

### DIFF
--- a/sdk/log/crate/Cargo.toml
+++ b/sdk/log/crate/Cargo.toml
@@ -15,7 +15,10 @@ crate-type = ["rlib"]
 pinocchio-log-macro = { workspace = true, optional = true }
 
 [lints.rust]
-unexpected_cfgs = {level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(target_feature, values("static-syscalls"))',
+] }
 
 [features]
 default = ["macro"]


### PR DESCRIPTION
**Problem**

Pinocchio logger declares syscalls as extern functions, but this method is not compatible with SBPFv3. If we build a program using the new v3 architecture, we'll encounter an invalid function error.

**Solution**

Declare static syscalls in an internal `syscall` module.