### PR TITLE
Remove *const cast

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -556,7 +556,7 @@ impl AccountInfo {
 
     /// Returns the memory address of the account data.
     fn data_ptr(&self) -> *mut u8 {
-        unsafe { (self.raw as *const _ as *mut u8).add(core::mem::size_of::<Account>()) }
+        unsafe { (self.raw as *mut u8).add(core::mem::size_of::<Account>()) }
     }
 }
 


### PR DESCRIPTION
### Problem

The way the data pointer (`data_ptr`) is calculated to access account data within an `AccountInfo` does an unnecessary cast to `*const _` before casting to `*mut u8`. Since `self.raw` is already a `*mut` pointer, it can be casted to `*mut u8` directly.

### Solution

Remove the unnecessary `*const _`.