### PR TITLE
Update doc comments on close account

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -522,7 +522,7 @@ impl AccountInfo {
     /// Zero out the the account's data length, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// Note: This does not zeroes the account data. The account data will be zeroed by
+    /// Note: This does not zero the account data. The account data will be zeroed by
     /// the runtime at the end of the instruction where the account was closed or at the
     /// next CPI call.
     ///

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -495,10 +495,9 @@ impl AccountInfo {
     /// Zero out the the account's data length, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// This doesn't protect against future reinitialization of the account
-    /// since the account data will need to be zeroed out as well; otherwise the lenght,
-    /// lamports and owner can be set again before the data is wiped out from
-    /// the ledger using the keypair of the account being closed.
+    /// Note: This does not zeroes the account data. The account data will be zeroed by
+    /// the runtime at the end of the instruction where the account was closed or at the
+    /// next CPI call.
     ///
     /// # Important
     ///
@@ -523,10 +522,9 @@ impl AccountInfo {
     /// Zero out the the account's data length, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// This doesn't protect against future reinitialization of the account
-    /// since the account data will need to be zeroed out as well; otherwise the lenght,
-    /// lamports and owner can be set again before the data is wiped out from
-    /// the ledger using the keypair of the account being closed.
+    /// Note: This does not zeroes the account data. The account data will be zeroed by
+    /// the runtime at the end of the instruction where the account was closed or at the
+    /// next CPI call.
     ///
     /// # Important
     ///

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -495,7 +495,7 @@ impl AccountInfo {
     /// Zero out the the account's data length, lamports and owner fields, effectively
     /// closing the account.
     ///
-    /// Note: This does not zeroes the account data. The account data will be zeroed by
+    /// Note: This does not zero the account data. The account data will be zeroed by
     /// the runtime at the end of the instruction where the account was closed or at the
     /// next CPI call.
     ///


### PR DESCRIPTION
### Problem

Currently the doc comments for the `close` account does not specify when the account data will be zeroed and suggests that it might be possible to reinitialize the same account with the old data, which is not the case.

### Solution

This PR clarifies when the data will zeroed by the runtime after the account is closed.