### PR TITLE
Fix `assign` unsoundness

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -2,7 +2,7 @@
 use core::{
     marker::PhantomData,
     mem::ManuallyDrop,
-    ptr::NonNull,
+    ptr::{write, NonNull},
     slice::{from_raw_parts, from_raw_parts_mut},
 };
 
@@ -123,8 +123,8 @@ impl AccountInfo {
     ///
     /// # Safety
     ///
-    /// A reference returned by this method is invalidated when [`Self::assign`]
-    /// is called.
+    /// It is undefined behaviour to use [`Self::assign`] while there is an active reference
+    /// to the `owner` returned by this method.
     #[inline(always)]
     pub unsafe fn owner(&self) -> &Pubkey {
         &(*self.raw).owner
@@ -173,18 +173,18 @@ impl AccountInfo {
     /// Checks if the account is owned by the given program.
     #[inline(always)]
     pub fn is_owned_by(&self, program: &Pubkey) -> bool {
-        unsafe { &(*self.raw).owner == program }
+        unsafe { self.owner() == program }
     }
 
     /// Changes the owner of the account.
     ///
     /// # Safety
     ///
-    /// Using this method invalidates any reference returned by [`Self::owner`].
+    /// It is undefined behaviour to use this method while there is an active reference
+    /// to the `owner` returned by [`Self::owner`].
     #[inline(always)]
     pub unsafe fn assign(&self, new_owner: &Pubkey) {
-        #[allow(invalid_reference_casting)]
-        core::ptr::write_volatile(&(*self.raw).owner as *const _ as *mut Pubkey, *new_owner);
+        write(&mut (*self.raw).owner, *new_owner);
     }
 
     /// Return true if the account borrow state is set to the given state.


### PR DESCRIPTION
### Problem

The current implementation of `AccountInfo::assign` is unsound since it takes an immutable reference to `owner` and casts it to a mutable one:
```
&(*self.raw).owner as *const _ as *mut Pubkey
```

### Solution

Use a mutable reference to `owner` directly. This PR also clarifies the safety assumptions for `owner()` and `assign()`.

cc: @d0nutptr