### PR TITLE
system: Fix signer flag

### DIFF
--- a/programs/system/src/instructions/allocate_with_seed.rs
+++ b/programs/system/src/instructions/allocate_with_seed.rs
@@ -43,7 +43,7 @@ impl AllocateWithSeed<'_, '_, '_> {
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 2] = [
-            AccountMeta::writable_signer(self.account.key()),
+            AccountMeta::writable(self.account.key()),
             AccountMeta::readonly_signer(self.base.key()),
         ];
 

--- a/programs/system/src/instructions/assign_with_seed.rs
+++ b/programs/system/src/instructions/assign_with_seed.rs
@@ -39,7 +39,7 @@ impl AssignWithSeed<'_, '_, '_> {
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 2] = [
-            AccountMeta::writable_signer(self.account.key()),
+            AccountMeta::writable(self.account.key()),
             AccountMeta::readonly_signer(self.base.key()),
         ];
 


### PR DESCRIPTION
### Problem

Current both `allocate_with_seed` and `assign_with_seed` mark the first account as a writable signer, while the program only expects the account to be writable.

### Solution

Update the instruction builders to mark the account as writable only.

cc: @d0nutptr