### PR TITLE
token: Fix instruction data length

### DIFF
--- a/programs/token/src/instructions/initialize_mint_2.rs
+++ b/programs/token/src/instructions/initialize_mint_2.rs
@@ -42,6 +42,7 @@ impl InitializeMint2<'_> {
         // -  [34]: freeze_authority presence flag (1 byte, u8)
         // -  [35..67]: freeze_authority (optional, 32 bytes, Pubkey)
         let mut instruction_data = [UNINIT_BYTE; 67];
+        let mut length = instruction_data.len();
 
         // Set discriminator as u8 at offset [0]
         write_bytes(&mut instruction_data, &[20]);
@@ -49,18 +50,22 @@ impl InitializeMint2<'_> {
         write_bytes(&mut instruction_data[1..2], &[self.decimals]);
         // Set mint_authority as Pubkey at offset [2..34]
         write_bytes(&mut instruction_data[2..34], self.mint_authority);
-        // Set COption & freeze_authority at offset [34..67]
+
         if let Some(freeze_auth) = self.freeze_authority {
+            // Set Option = `true` & freeze_authority at offset [34..67]
             write_bytes(&mut instruction_data[34..35], &[1]);
             write_bytes(&mut instruction_data[35..], freeze_auth);
         } else {
+            // Set Option = `false`
             write_bytes(&mut instruction_data[34..35], &[0]);
+            // Adjust length if no freeze authority
+            length = 35;
         }
 
         let instruction = Instruction {
             program_id: &crate::ID,
             accounts: &account_metas,
-            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 67) },
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, length) },
         };
 
         invoke_signed(&instruction, &[self.mint], signers)


### PR DESCRIPTION
### Problem

The helpers `initialize_mint`, `initialize_mint_2` and `set_authority` for the token program include an optional `Pubkey` in their instruction data. When  the optional pubkey ise not present, the length of the instruction data is not being updated, which creates an UB situation.

### Solution

Adjust the instruction data length according to whether the optional pubkey is present or not.

cc: @d0nutptr