### PR TITLE
fix: use `pinocchio` workspace dep in the `memo` program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-memo"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "pinocchio",
  "pinocchio-pubkey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-memo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pinocchio",
  "pinocchio-pubkey",

--- a/programs/memo/Cargo.toml
+++ b/programs/memo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio-memo"
 description = "Pinocchio helpers to invoke Memo program instructions"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"
@@ -12,5 +12,5 @@ rust-version = { workspace = true }
 crate-type = ["rlib"]
 
 [dependencies]
-pinocchio = { version = "0.8.4", path = "../../sdk/pinocchio" }
+pinocchio = { workspace = true }
 pinocchio-pubkey = { workspace = true }

--- a/programs/memo/Cargo.toml
+++ b/programs/memo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pinocchio-memo"
 description = "Pinocchio helpers to invoke Memo program instructions"
-version = "0.1.1"
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 readme = "./README.md"


### PR DESCRIPTION
### Problem
memo program uses pinned `pinocchio` dependency

### Solution
use workspace dependency instead of pinned one

cc @publicqi 