### PR TITLE
Clarify the use of constant values

### DIFF
--- a/scripts/setup/solana.dic
+++ b/scripts/setup/solana.dic
@@ -64,3 +64,4 @@ RPC
 ed25519
 performant
 syscall/S
+bitmask

--- a/sdk/pinocchio/src/instruction.rs
+++ b/sdk/pinocchio/src/instruction.rs
@@ -73,35 +73,35 @@ pub struct Account<'a> {
     _account_info: PhantomData<&'a AccountInfo>,
 }
 
-/// Return a pointer to a type `U` given a source pointer for `T` and the relative offset
-/// to `U` in units of `T`.
+/// Return a pointer to a type `U` given type `T` has a field of type `U` at the specified
+/// offset (in bytes) from the start of the `T` type.
 ///
 /// # Safety
 ///
-/// The caller must ensure that the `source` pointer is valid for `T` and that the offset is
-/// within the bounds of the memory region pointed to by `source`. The resulting pointer must
-/// at an aligned memory location that can be safely cast to `*const U`.
+/// The caller must ensure that the `ptr` is a valid pointer to a type `T`, and `ptr + offset`
+/// points to bytes that are properly aligned for `U` and represent a bit pattern that is a
+/// valid instance of `U`.
 ///
 /// If any of this requirements is not valid, this function leads to undefined behavior.
 #[inline(always)]
-const unsafe fn offset<T, U>(source: *const T, offset: usize) -> *const U {
+const unsafe fn field_at_offset<T, U>(ptr: *const T, offset: usize) -> *const U {
     // SAFETY: The caller ensures that the offset is valid for the type `T` and that
     // the resulting pointer is valid for type `U`.
-    unsafe { (source as *const u8).add(offset) as *const U }
+    unsafe { (ptr as *const u8).add(offset) as *const U }
 }
 
 impl<'a> From<&'a AccountInfo> for Account<'a> {
     fn from(account: &'a AccountInfo) -> Self {
         Account {
             // SAFETY: offset `8` is the `key` field in the `Account` struct.
-            key: unsafe { offset(account.raw, 8) },
+            key: unsafe { field_at_offset(account.raw, 8) },
             // SAFETY: offset `72` is the `lamports` field in the `Account` struct.
-            lamports: unsafe { offset(account.raw, 72) },
+            lamports: unsafe { field_at_offset(account.raw, 72) },
             data_len: account.data_len() as u64,
             // SAFETY: offset `88` is the start of the account data in the `Account` struct.
-            data: unsafe { offset(account.raw, 88) },
+            data: unsafe { field_at_offset(account.raw, 88) },
             // SAFETY: offset `40` is the `owner` field in the `Account` struct.
-            owner: unsafe { offset(account.raw, 40) },
+            owner: unsafe { field_at_offset(account.raw, 40) },
             // The `rent_epoch` field is not present in the `AccountInfo` struct,
             // since the value occurs after the variable data of the account in
             // the runtime input data.


### PR DESCRIPTION
### Problem

There are a few places where "raw" values (magic numbers) are being used, which might not clearly describe their use.

### Solution

This PR improves the documentation for these values. Additionally, it updates the name of the function used to calculate a pointer offset to a field of a type (`offset` -> `field_at_offset`) to better represent its purpose – this is a function used with "raw" values.

This is an alternative to PR #191 