### PR TITLE
pubkey: Update const dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,20 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-crypto"
-version = "0.3.0"
+name = "five8_const"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c06f1eb05f06cf2e380fdded278fbf056a38974299d77960555a311dcf91a52"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
- "keccak-const",
- "sha2-const-stable",
+ "five8_core",
 ]
 
 [[package]]
-name = "keccak-const"
-version = "0.2.0"
+name = "five8_core"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "memchr"
@@ -73,8 +72,9 @@ dependencies = [
 name = "pinocchio-pubkey"
 version = "0.2.4"
 dependencies = [
- "const-crypto",
+ "five8_const",
  "pinocchio",
+ "sha2-const-stable",
 ]
 
 [[package]]

--- a/sdk/pubkey/Cargo.toml
+++ b/sdk/pubkey/Cargo.toml
@@ -18,8 +18,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [features]
 default = ["const"]
-const = ["dep:const-crypto"]
+const = ["dep:five8_const", "dep:sha2-const-stable"]
 
 [dependencies]
-const-crypto = { version = "0.3.0", optional = true }
+five8_const = { workspace = true, optional = true }
+sha2-const-stable = { version = "0.1.0", optional = true }
 pinocchio = { workspace = true }

--- a/sdk/pubkey/src/lib.rs
+++ b/sdk/pubkey/src/lib.rs
@@ -7,12 +7,14 @@ pub mod reexport {
     pub use pinocchio::pubkey::Pubkey;
 }
 
-#[cfg(feature = "const")]
-use const_crypto::{bs58::decode_pubkey, sha2::Sha256};
 use core::mem::MaybeUninit;
+#[cfg(feature = "const")]
+pub use five8_const::decode_32_const;
 use pinocchio::pubkey::{Pubkey, MAX_SEEDS, PDA_MARKER};
 #[cfg(target_os = "solana")]
 use pinocchio::syscalls::sol_sha256;
+#[cfg(feature = "const")]
+use sha2_const_stable::Sha256;
 
 /// Derive a [program address][pda] from the given seeds, optional bump and
 /// program id.
@@ -191,5 +193,5 @@ macro_rules! declare_id {
 #[cfg(feature = "const")]
 #[inline(always)]
 pub const fn from_str(value: &str) -> Pubkey {
-    decode_pubkey(value)
+    decode_32_const(value)
 }


### PR DESCRIPTION
### Problem

PR #192 changed the base58 conversion dependency when it introduced the one for sha2, although it could have simply added `sha2-const-stable`. 

### Solution

Revert to using `five8_const` for base58 conversion and use `sha2-const-stable` for sha2.