### PR TITLE
ci: Update git-cliff-action to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.dry_run != 'true' && github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: ".github/cliff.toml"
           args: |


### PR DESCRIPTION
### Problem

Currently the publish workflow is [failing](https://github.com/anza-xyz/pinocchio/actions/runs/16369318120/job/46253785576) when trying to build the docker image for `git-cliff-action@v3`.

### Solution

Use the newer version `git-cliff-action@v4`. A successful dry-run of the publish workflow is [here](https://github.com/anza-xyz/pinocchio/actions/runs/16369855502).