### PR TITLE
ci: Use single line `args` in git-cliff action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,10 +147,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: ".github/cliff.toml"
-          args: |
-            "${{ steps.publish.outputs.old_git_tag }}"..main
-            --include-path "${{ inputs.crate }}/**"
-            --github-repo "${{ github.repository }}"
+          args: "${{ steps.publish.outputs.old_git_tag }}..main --include-path ${{ inputs.crate }}/** --github-repo ${{ github.repository }}"
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
### Problem

Publishing the changelog of a release is currently [failing](https://github.com/anza-xyz/pinocchio/actions/runs/16506833556/job/46679542949) with:
```
/home/runner/work/_temp/3b272696-5f5f-438d-98f4-f0084559016a.sh: line 2: --include-path: command not found
```
It seems that since updating the git-cliff action to `v4` the multiline argument is being interpreted as multiple commands:
```
args: |
    "${{ steps.publish.outputs.old_git_tag }}"..main
    --include-path "${{ inputs.crate }}/**"
    --github-repo "${{ github.repository }}"
```

### Solution

Set the `args` parameter as a single line.