### PR TITLE
system: Fix instruction helpers

### DIFF
--- a/programs/system/src/instructions/initialize_nonce_account.rs
+++ b/programs/system/src/instructions/initialize_nonce_account.rs
@@ -1,15 +1,12 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
 
 /// Drive state of Uninitialized nonce account to Initialized, setting the nonce value.
-///
-/// The `Pubkey` parameter specifies the entity authorized to execute nonce
-/// instruction on the account
 ///
 /// No signatures are required to execute this instruction, enabling derived
 /// nonce account addresses.
@@ -28,21 +25,14 @@ pub struct InitializeNonceAccount<'a, 'b> {
     /// Rent sysvar.
     pub rent_sysvar: &'a AccountInfo,
 
-    /// Lamports to withdraw.
-    ///
-    /// The account balance must be left above the rent exempt reserve
-    /// or at zero.
+    /// Indicates the entity authorized to execute nonce
+    /// instruction on the account
     pub authority: &'b Pubkey,
 }
 
 impl InitializeNonceAccount<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 3] = [
             AccountMeta::writable(self.account.key()),
@@ -63,14 +53,13 @@ impl InitializeNonceAccount<'_, '_> {
             data: &instruction_data,
         };
 
-        invoke_signed(
+        invoke(
             &instruction,
             &[
                 self.account,
                 self.recent_blockhashes_sysvar,
                 self.rent_sysvar,
             ],
-            signers,
         )
     }
 }

--- a/programs/system/src/instructions/mod.rs
+++ b/programs/system/src/instructions/mod.rs
@@ -9,7 +9,7 @@ mod create_account_with_seed;
 mod initialize_nonce_account;
 mod transfer;
 mod transfer_with_seed;
-mod update_nonce_account;
+mod upgrade_nonce_account;
 mod withdraw_nonce_account;
 
 pub use advance_nonce_account::*;
@@ -23,5 +23,5 @@ pub use create_account_with_seed::*;
 pub use initialize_nonce_account::*;
 pub use transfer::*;
 pub use transfer_with_seed::*;
-pub use update_nonce_account::*;
+pub use upgrade_nonce_account::*;
 pub use withdraw_nonce_account::*;

--- a/programs/system/src/instructions/upgrade_nonce_account.rs
+++ b/programs/system/src/instructions/upgrade_nonce_account.rs
@@ -1,7 +1,7 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     ProgramResult,
 };
 
@@ -10,19 +10,14 @@ use pinocchio::{
 ///
 /// ### Accounts:
 ///   0. `[WRITE]` Nonce account
-pub struct UpdateNonceAccount<'a> {
+pub struct UpgradeNonceAccount<'a> {
     /// Nonce account.
     pub account: &'a AccountInfo,
 }
 
-impl UpdateNonceAccount<'_> {
+impl UpgradeNonceAccount<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.account.key())];
 
@@ -33,6 +28,6 @@ impl UpdateNonceAccount<'_> {
             data: &[12],
         };
 
-        invoke_signed(&instruction, &[self.account], signers)
+        invoke(&instruction, &[self.account])
     }
 }


### PR DESCRIPTION
### Problem

There are a couple of issues in the current system crate: (1) the `InitializeNonceAccount` offers a `invoke_signed` helper although the instruction does not require any signers; and (2) the correct name for `UpdateNonceAccount` is `UpgradeNonceAccount` and there is no need to include a `invoke_signed` helper since the instruction does not expect any signers.

### Solution

Remove the `invoke_signed` from both `InitializeNonceAccount` and `UpdateNonceAccount`, and rename `UpdateNonceAccount` to `UpgradeNonceAccount`.