### PR TITLE
token: Remove unnecessary `invoke_signed`

### DIFF
--- a/programs/token/src/instructions/initialize_account.rs
+++ b/programs/token/src/instructions/initialize_account.rs
@@ -1,7 +1,7 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     ProgramResult,
 };
 
@@ -26,11 +26,6 @@ pub struct InitializeAccount<'a> {
 impl InitializeAccount<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 4] = [
             AccountMeta::writable(self.account.key()),
@@ -45,10 +40,9 @@ impl InitializeAccount<'_> {
             data: &[1],
         };
 
-        invoke_signed(
+        invoke(
             &instruction,
             &[self.account, self.mint, self.owner, self.rent_sysvar],
-            signers,
         )
     }
 }

--- a/programs/token/src/instructions/initialize_account_2.rs
+++ b/programs/token/src/instructions/initialize_account_2.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -30,11 +30,6 @@ pub struct InitializeAccount2<'a> {
 impl InitializeAccount2<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 3] = [
             AccountMeta::writable(self.account.key()),
@@ -58,10 +53,6 @@ impl InitializeAccount2<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 33) },
         };
 
-        invoke_signed(
-            &instruction,
-            &[self.account, self.mint, self.rent_sysvar],
-            signers,
-        )
+        invoke(&instruction, &[self.account, self.mint, self.rent_sysvar])
     }
 }

--- a/programs/token/src/instructions/initialize_account_3.rs
+++ b/programs/token/src/instructions/initialize_account_3.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -27,11 +27,6 @@ pub struct InitializeAccount3<'a> {
 impl InitializeAccount3<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 2] = [
             AccountMeta::writable(self.account.key()),
@@ -54,6 +49,6 @@ impl InitializeAccount3<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 33) },
         };
 
-        invoke_signed(&instruction, &[self.account, self.mint], signers)
+        invoke(&instruction, &[self.account, self.mint])
     }
 }

--- a/programs/token/src/instructions/initialize_mint.rs
+++ b/programs/token/src/instructions/initialize_mint.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -31,11 +31,6 @@ pub struct InitializeMint<'a> {
 impl InitializeMint<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // Account metadata
         let account_metas: [AccountMeta; 2] = [
             AccountMeta::writable(self.mint.key()),
@@ -75,6 +70,6 @@ impl InitializeMint<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, length) },
         };
 
-        invoke_signed(&instruction, &[self.mint, self.rent_sysvar], signers)
+        invoke(&instruction, &[self.mint, self.rent_sysvar])
     }
 }

--- a/programs/token/src/instructions/initialize_mint_2.rs
+++ b/programs/token/src/instructions/initialize_mint_2.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -28,11 +28,6 @@ pub struct InitializeMint2<'a> {
 impl InitializeMint2<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // Account metadata
         let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.mint.key())];
 
@@ -69,6 +64,6 @@ impl InitializeMint2<'_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, length) },
         };
 
-        invoke_signed(&instruction, &[self.mint], signers)
+        invoke(&instruction, &[self.mint])
     }
 }

--- a/programs/token/src/instructions/sync_native.rs
+++ b/programs/token/src/instructions/sync_native.rs
@@ -1,7 +1,7 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     ProgramResult,
 };
 
@@ -19,11 +19,6 @@ pub struct SyncNative<'a> {
 impl SyncNative<'_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.native_token.key())];
 
@@ -33,6 +28,6 @@ impl SyncNative<'_> {
             data: &[17],
         };
 
-        invoke_signed(&instruction, &[self.native_token], signers)
+        invoke(&instruction, &[self.native_token])
     }
 }


### PR DESCRIPTION
### Problem

There are a few instructions that provide an `invoke_signed` method although the instruction does not require any signer.

### Solution

Remove the unnecessary `invoke_signed`.