### PR TITLE
token-2022: Remove unnecessary `invoke_signed`

### DIFF
--- a/programs/token-2022/src/instructions/initialize_account.rs
+++ b/programs/token-2022/src/instructions/initialize_account.rs
@@ -1,7 +1,7 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -29,11 +29,6 @@ pub struct InitializeAccount<'a, 'b> {
 impl InitializeAccount<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 4] = [
             AccountMeta::writable(self.account.key()),
@@ -48,10 +43,9 @@ impl InitializeAccount<'_, '_> {
             data: &[1],
         };
 
-        invoke_signed(
+        invoke(
             &instruction,
             &[self.account, self.mint, self.owner, self.rent_sysvar],
-            signers,
         )
     }
 }

--- a/programs/token-2022/src/instructions/initialize_account_2.rs
+++ b/programs/token-2022/src/instructions/initialize_account_2.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -32,11 +32,6 @@ pub struct InitializeAccount2<'a, 'b> {
 impl InitializeAccount2<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 3] = [
             AccountMeta::writable(self.account.key()),
@@ -60,10 +55,6 @@ impl InitializeAccount2<'_, '_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 33) },
         };
 
-        invoke_signed(
-            &instruction,
-            &[self.account, self.mint, self.rent_sysvar],
-            signers,
-        )
+        invoke(&instruction, &[self.account, self.mint, self.rent_sysvar])
     }
 }

--- a/programs/token-2022/src/instructions/initialize_account_3.rs
+++ b/programs/token-2022/src/instructions/initialize_account_3.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -29,11 +29,6 @@ pub struct InitializeAccount3<'a, 'b> {
 impl InitializeAccount3<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 2] = [
             AccountMeta::writable(self.account.key()),
@@ -56,6 +51,6 @@ impl InitializeAccount3<'_, '_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, 33) },
         };
 
-        invoke_signed(&instruction, &[self.account, self.mint], signers)
+        invoke(&instruction, &[self.account, self.mint])
     }
 }

--- a/programs/token-2022/src/instructions/initialize_mint.rs
+++ b/programs/token-2022/src/instructions/initialize_mint.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -33,11 +33,6 @@ pub struct InitializeMint<'a, 'b> {
 impl InitializeMint<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // Account metadata
         let account_metas: [AccountMeta; 2] = [
             AccountMeta::writable(self.mint.key()),
@@ -77,6 +72,6 @@ impl InitializeMint<'_, '_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, length) },
         };
 
-        invoke_signed(&instruction, &[self.mint, self.rent_sysvar], signers)
+        invoke(&instruction, &[self.mint, self.rent_sysvar])
     }
 }

--- a/programs/token-2022/src/instructions/initialize_mint_2.rs
+++ b/programs/token-2022/src/instructions/initialize_mint_2.rs
@@ -2,8 +2,8 @@ use core::slice::from_raw_parts;
 
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -30,11 +30,6 @@ pub struct InitializeMint2<'a, 'b> {
 impl InitializeMint2<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // Account metadata
         let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.mint.key())];
 
@@ -71,6 +66,6 @@ impl InitializeMint2<'_, '_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, length) },
         };
 
-        invoke_signed(&instruction, &[self.mint], signers)
+        invoke(&instruction, &[self.mint])
     }
 }

--- a/programs/token-2022/src/instructions/sync_native.rs
+++ b/programs/token-2022/src/instructions/sync_native.rs
@@ -1,7 +1,7 @@
 use pinocchio::{
     account_info::AccountInfo,
-    instruction::{AccountMeta, Instruction, Signer},
-    program::invoke_signed,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     ProgramResult,
 };
@@ -22,11 +22,6 @@ pub struct SyncNative<'a, 'b> {
 impl SyncNative<'_, '_> {
     #[inline(always)]
     pub fn invoke(&self) -> ProgramResult {
-        self.invoke_signed(&[])
-    }
-
-    #[inline(always)]
-    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
         // account metadata
         let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.native_token.key())];
 
@@ -36,6 +31,6 @@ impl SyncNative<'_, '_> {
             data: &[17],
         };
 
-        invoke_signed(&instruction, &[self.native_token], signers)
+        invoke(&instruction, &[self.native_token])
     }
 }


### PR DESCRIPTION
### Problem

There are a few instructions that provide an `invoke_signed` method although the instruction does not require any signer.

### Solution

Remove the unnecessary `invoke_signed`.