### PR TITLE
Add resize_unchecked method to account info

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -495,6 +495,25 @@ impl AccountInfo {
         // Check wheather the account data is already borrowed.
         self.can_borrow_mut_data()?;
 
+        // SAFETY:
+        // We are checking if the account data is already borrowed, so we are safe to call
+        unsafe {
+            self.resize_unchecked(new_len)?;
+        }
+
+        Ok(())
+    }
+
+    /// Resizes the account's data and udpates the resize delta without checking if the account is already borrowed.
+    ///
+    /// The account data can be increased by up to [`MAX_PERMITTED_DATA_INCREASE`] bytes
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it does not check if the account data is already
+    /// borrowed.
+    #[inline(always)]
+    pub unsafe fn resize_unchecked(&self, new_len: usize) -> Result<(), ProgramError> {
         // Account length is always `< i32::MAX`...
         let current_len = self.data_len() as i32;
         // ...so the new length must fit in an `i32`.

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -497,11 +497,7 @@ impl AccountInfo {
 
         // SAFETY:
         // We are checking if the account data is already borrowed, so we are safe to call
-        unsafe {
-            self.resize_unchecked(new_len)?;
-        }
-
-        Ok(())
+        unsafe { self.resize_unchecked(new_len) }
     }
 
     /// Resizes the account's data and udpates the resize delta without checking if the account is already borrowed.

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -507,7 +507,8 @@ impl AccountInfo {
     /// # Safety
     ///
     /// This method is unsafe because it does not check if the account data is already
-    /// borrowed.
+    /// borrowed. The caller must guarantee that there are no active borrows to the account
+    /// data.
     #[inline(always)]
     pub unsafe fn resize_unchecked(&self, new_len: usize) -> Result<(), ProgramError> {
         // Account length is always `< i32::MAX`...

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -500,7 +500,7 @@ impl AccountInfo {
         unsafe { self.resize_unchecked(new_len) }
     }
 
-    /// Resizes the account's data and udpates the resize delta without checking if the account is already borrowed.
+    /// Resize (either truncating or zero extending) the account's data.
     ///
     /// The account data can be increased by up to [`MAX_PERMITTED_DATA_INCREASE`] bytes
     ///


### PR DESCRIPTION
We retain control of the `RefMut` and need to be able to resize the account without going through the borrow check. This enables that, and is unsafe to indicate that the borrow check isn't being done.