### PR TITLE
Feat: make AccountInfo::data_ptr public

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -627,8 +627,8 @@ impl AccountInfo {
     /// Returns the memory address of the account data.
     /// # Important
     ///
-    /// Obtaining the raw pointer itself is safe, but dereferencing it requires
-    /// the caller to uphold Rust’s aliasing rules. It is undefined behavior to dereference
+    /// Obtaining the raw pointer itself is safe, but de-referencing it requires
+    /// the caller to uphold Rust's aliasing rules. It is undefined behavior to de-reference
     /// the pointer or write through it while any safe reference (e.g., from any of `borrow_data`
     /// or `borrow_mut_data` methods) to the same data is still alive.
     pub fn data_ptr(&self) -> *mut u8 {

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -609,6 +609,12 @@ impl AccountInfo {
     }
 
     /// Returns the memory address of the account data.
+    /// # Important
+    ///
+    /// Obtaining the raw pointer itself is safe, but dereferencing it requires
+    /// the caller to uphold Rust’s aliasing rules. It is undefined behavior to dereference
+    /// the pointer or write through it while any safe reference (e.g., from any of `borrow_data`
+    /// or `borrow_mut_data` methods) to the same data is still alive.
     pub fn data_ptr(&self) -> *mut u8 {
         unsafe { (self.raw as *mut u8).add(core::mem::size_of::<Account>()) }
     }

--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -609,7 +609,7 @@ impl AccountInfo {
     }
 
     /// Returns the memory address of the account data.
-    fn data_ptr(&self) -> *mut u8 {
+    pub fn data_ptr(&self) -> *mut u8 {
         unsafe { (self.raw as *mut u8).add(core::mem::size_of::<Account>()) }
     }
 }


### PR DESCRIPTION
Useful for unsafe operations that need to access the data pointer in a stable way without going through a reborrow