### PR TITLE
Add token-2022 to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ on:
           - programs/memo
           - programs/system
           - programs/token
+          - programs/token-2022
           - sdk/log/crate
           - sdk/log/macro
           - sdk/pinocchio


### PR DESCRIPTION
### Problem

There is now a CPI helpers crate for SPL Token 2022 program, but it is currently not integrated in the publish workflow.

### Solution

Add the crate to the publish workflow.