### PR TITLE
Add default account state extension instruction helpers for pinocchio token 2022

### DIFF
--- a/programs/token-2022/src/extensions/default_account_state/instructions/initialize_default_account_state.rs
+++ b/programs/token-2022/src/extensions/default_account_state/instructions/initialize_default_account_state.rs
@@ -1,0 +1,45 @@
+use crate::{
+    extensions::default_account_state::state::{
+        encode_instruction_data, DefaultAccountStateInstruction,
+    },
+    state::AccountState,
+};
+use core::slice::from_raw_parts;
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke_signed,
+    instruction::{AccountMeta, Instruction, Signer},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+pub struct InitializeDefaultAccountState<'a, 'b> {
+    /// Mint Account.
+    pub mint: &'a AccountInfo,
+    /// Token Program
+    pub token_program: &'b Pubkey,
+    /// Account State
+    pub state: AccountState,
+}
+
+impl InitializeDefaultAccountState<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let account_metas = [AccountMeta::writable(self.mint.key())];
+
+        let data = encode_instruction_data(DefaultAccountStateInstruction::Initialize, self.state);
+
+        let instruction = Instruction {
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(data.as_ptr() as _, data.len()) },
+            program_id: self.token_program,
+        };
+
+        invoke_signed(&instruction, &[self.mint], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/default_account_state/instructions/mod.rs
+++ b/programs/token-2022/src/extensions/default_account_state/instructions/mod.rs
@@ -1,0 +1,6 @@
+/// Default Account state extension instructions
+mod initialize_default_account_state;
+mod update_default_account_state;
+
+pub use initialize_default_account_state::*;
+pub use update_default_account_state::*;

--- a/programs/token-2022/src/extensions/default_account_state/instructions/update_default_account_state.rs
+++ b/programs/token-2022/src/extensions/default_account_state/instructions/update_default_account_state.rs
@@ -1,0 +1,50 @@
+use crate::{
+    extensions::default_account_state::state::{
+        encode_instruction_data, DefaultAccountStateInstruction,
+    },
+    state::AccountState,
+};
+use core::slice::from_raw_parts;
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke_signed,
+    instruction::{AccountMeta, Instruction, Signer},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+pub struct UpdateDefaultAccountState<'a, 'b> {
+    /// Mint Account.
+    pub mint: &'a AccountInfo,
+    /// Freeze Authority Account.
+    pub freeze_authority: &'a AccountInfo,
+    /// Token Program
+    pub token_program: &'b Pubkey,
+    /// Account State
+    pub state: AccountState,
+}
+
+impl UpdateDefaultAccountState<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let account_metas = [
+            AccountMeta::writable(self.mint.key()),
+            AccountMeta::readonly_signer(self.freeze_authority.key()),
+        ];
+
+        let data = encode_instruction_data(DefaultAccountStateInstruction::Update, self.state);
+
+        let instruction = Instruction {
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(data.as_ptr() as _, data.len()) },
+            program_id: self.token_program,
+        };
+
+        invoke_signed(&instruction, &[self.mint, self.freeze_authority], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/default_account_state/mod.rs
+++ b/programs/token-2022/src/extensions/default_account_state/mod.rs
@@ -1,0 +1,5 @@
+/// Default Account state extension instructions
+pub mod instructions;
+
+/// Default Account state extension state helpers
+pub mod state;

--- a/programs/token-2022/src/extensions/default_account_state/state.rs
+++ b/programs/token-2022/src/extensions/default_account_state/state.rs
@@ -1,0 +1,31 @@
+use crate::{state::AccountState, write_bytes, UNINIT_BYTE};
+use core::mem::MaybeUninit;
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DefaultAccountStateInstruction {
+    Initialize,
+    Update,
+}
+
+/// Discriminator for the DefaultAccountState extension.
+const DEFAULT_ACCOUNT_STATE_EXTENSION: u8 = 28;
+
+/// Packs instruction data for a `DefaultAccountStateInstruction`
+pub fn encode_instruction_data(
+    instruction_type: DefaultAccountStateInstruction,
+    state: AccountState,
+) -> [MaybeUninit<u8>; 3] {
+    // instruction data
+    // -  [0]: instruction discriminator (1 byte, u8)
+    // -  [1]: instruction_type (1 byte, u8)
+    // -  [1]: account state (1 byte, u8)
+    let mut data = [UNINIT_BYTE; 3];
+    // Set discriminator as u8 at offset [0]
+    write_bytes(&mut data, &[DEFAULT_ACCOUNT_STATE_EXTENSION]);
+    // Set instruction_type as u8 at offset [1]
+    write_bytes(&mut data[1..2], &[instruction_type as u8]);
+    // Set account state as u8 at offset [2]
+    write_bytes(&mut data[2..3], &[state as u8]);
+    data
+}

--- a/programs/token-2022/src/extensions/mod.rs
+++ b/programs/token-2022/src/extensions/mod.rs
@@ -1,0 +1,4 @@
+//! Extensions available to token mints and accounts
+
+/// Default Account State extension
+pub mod default_account_state;

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod extensions;
 pub mod instructions;
 pub mod state;
 


### PR DESCRIPTION
### Description

Create a pinocchio version of the token 2022 extension: `Default Account State`.

> Follows patterns from the `set_authority` instruction which seems to parallel the `default_account_state` extension requirements.