### PR TITLE
Revert "entrypoint: remove unnecessary deser case"

### DIFF
--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -353,31 +353,35 @@ pub unsafe fn deserialize<const MAX_ACCOUNTS: usize>(
             // This is an optimization to reduce the number of jumps required to process the
             // accounts. The macro `process_accounts` will generate inline code to process the
             // specified number of accounts.
-            while to_process_plus_one > 5 {
-                // Process 5 accounts at a time.
-                process_accounts!(5 => (input, accounts, accounts_slice));
-                to_process_plus_one -= 5;
-            }
+            if to_process_plus_one == 2 {
+                process_accounts!(1 => (input, accounts, accounts_slice));
+            } else {
+                while to_process_plus_one > 5 {
+                    // Process 5 accounts at a time.
+                    process_accounts!(5 => (input, accounts, accounts_slice));
+                    to_process_plus_one -= 5;
+                }
 
-            // There might be remaining accounts to process.
-            match to_process_plus_one {
-                5 => {
-                    process_accounts!(4 => (input, accounts, accounts_slice));
-                }
-                4 => {
-                    process_accounts!(3 => (input, accounts, accounts_slice));
-                }
-                3 => {
-                    process_accounts!(2 => (input, accounts, accounts_slice));
-                }
-                2 => {
-                    process_accounts!(1 => (input, accounts, accounts_slice));
-                }
-                1 => (),
-                _ => {
-                    // SAFETY: `while` loop above makes sure that `to_process_plus_one`
-                    // has 1 to 5 entries left.
-                    unsafe { core::hint::unreachable_unchecked() }
+                // There might be remaining accounts to process.
+                match to_process_plus_one {
+                    5 => {
+                        process_accounts!(4 => (input, accounts, accounts_slice));
+                    }
+                    4 => {
+                        process_accounts!(3 => (input, accounts, accounts_slice));
+                    }
+                    3 => {
+                        process_accounts!(2 => (input, accounts, accounts_slice));
+                    }
+                    2 => {
+                        process_accounts!(1 => (input, accounts, accounts_slice));
+                    }
+                    1 => (),
+                    _ => {
+                        // SAFETY: `while` loop above makes sure that `to_process_plus_one`
+                        // has 1 to 5 entries left.
+                        unsafe { core::hint::unreachable_unchecked() }
+                    }
                 }
             }
 


### PR DESCRIPTION
### Problem

This change affected parsing of input with `2` accounts to a larger degree than the gains provided to other number of accounts.

### Solution

Revert the change.

Reverts anza-xyz/pinocchio#233