### PR TITLE
pinocchio: Move `NON_DUP_MARKER` const

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -834,7 +834,7 @@ impl<T: ?Sized> Drop for RefMut<'_, T> {
 mod tests {
     use core::mem::{size_of, MaybeUninit};
 
-    use crate::NON_DUP_MARKER as NOT_BORROWED;
+    use crate::entrypoint::NON_DUP_MARKER as NOT_BORROWED;
 
     use super::*;
 

--- a/sdk/pinocchio/src/entrypoint/lazy.rs
+++ b/sdk/pinocchio/src/entrypoint/lazy.rs
@@ -3,10 +3,10 @@
 
 use crate::{
     account_info::{Account, AccountInfo},
-    entrypoint::STATIC_ACCOUNT_DATA,
+    entrypoint::{NON_DUP_MARKER, STATIC_ACCOUNT_DATA},
     program_error::ProgramError,
     pubkey::Pubkey,
-    BPF_ALIGN_OF_U128, NON_DUP_MARKER,
+    BPF_ALIGN_OF_U128,
 };
 
 /// Declare the lazy program entrypoint.

--- a/sdk/pinocchio/src/entrypoint/mod.rs
+++ b/sdk/pinocchio/src/entrypoint/mod.rs
@@ -19,7 +19,7 @@ use core::{
 use crate::{
     account_info::{Account, AccountInfo, MAX_PERMITTED_DATA_INCREASE},
     pubkey::Pubkey,
-    BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS, NON_DUP_MARKER,
+    BPF_ALIGN_OF_U128, MAX_TX_ACCOUNTS,
 };
 
 /// Start address of the memory region used for program heap.
@@ -38,6 +38,9 @@ pub type ProgramResult = super::ProgramResult;
 #[deprecated(since = "0.6.0", note = "Use `SUCCESS` from the crate root instead")]
 /// Return value for a successful program execution.
 pub const SUCCESS: u64 = super::SUCCESS;
+
+/// Value used to indicate that a serialized account is not a duplicate.
+pub const NON_DUP_MARKER: u8 = u8::MAX;
 
 /// The "static" size of an account in the input buffer.
 ///

--- a/sdk/pinocchio/src/lib.rs
+++ b/sdk/pinocchio/src/lib.rs
@@ -256,9 +256,6 @@ pub const MAX_TX_ACCOUNTS: usize = (u8::MAX - 1) as usize;
 /// for some host machines.
 const BPF_ALIGN_OF_U128: usize = 8;
 
-/// Value used to indicate that a serialized account is not a duplicate.
-const NON_DUP_MARKER: u8 = u8::MAX;
-
 /// Return value for a successful program execution.
 pub const SUCCESS: u64 = 0;
 

--- a/sdk/pinocchio/src/sysvars/slot_hashes/test.rs
+++ b/sdk/pinocchio/src/sysvars/slot_hashes/test.rs
@@ -424,7 +424,7 @@ fn test_from_account_info_constructor() {
         ptr::write(
             header_ptr,
             AccountLayout {
-                borrow_state: crate::NON_DUP_MARKER,
+                borrow_state: crate::entrypoint::NON_DUP_MARKER,
                 is_signer: 0,
                 is_writable: 0,
                 executable: 0,

--- a/sdk/pinocchio/src/sysvars/slot_hashes/test_edge.rs
+++ b/sdk/pinocchio/src/sysvars/slot_hashes/test_edge.rs
@@ -5,7 +5,8 @@ use super::test_utils::{build_slot_hashes_bytes as raw_slot_hashes, make_account
 #[test]
 fn test_wrong_key_from_account_info() {
     let bytes = raw_slot_hashes(0, &[]);
-    let (info, _backing) = unsafe { make_account_info([1u8; 32], &bytes, crate::NON_DUP_MARKER) };
+    let (info, _backing) =
+        unsafe { make_account_info([1u8; 32], &bytes, crate::entrypoint::NON_DUP_MARKER) };
     assert!(matches!(
         SlotHashes::from_account_info(&info),
         Err(ProgramError::InvalidArgument)


### PR DESCRIPTION
### Problem

Currently the `NON_DUP_MARKER` value is private to the crate, although it might be used by dependents.

### Solution

Move it to the entrypoint module and make it public.