### PR TITLE
check account size & type if extensions

### DIFF
--- a/programs/token-2022/src/state/account_state.rs
+++ b/programs/token-2022/src/state/account_state.rs
@@ -34,3 +34,28 @@ impl From<AccountState> for u8 {
         }
     }
 }
+
+/// Different kinds of accounts. Note that `Mint`, `TokenAccount`, and `Multisig`
+/// types are determined exclusively by the size of the account, and are not
+/// included in the account data. `AccountType` is only included if extensions
+/// have been initialized.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccountType {
+    /// Marker for 0 data
+    Uninitialized,
+    /// Mint account with additional extensions
+    Mint,
+    /// Token holding account with additional extensions
+    TokenAccount,
+}
+
+impl From<AccountType> for u8 {
+    fn from(value: AccountType) -> Self {
+        match value {
+            AccountType::Uninitialized => 0,
+            AccountType::Mint => 1,
+            AccountType::TokenAccount => 2,
+        }
+    }
+}


### PR DESCRIPTION
when deserializing accounts with extensions, it must be ensured that they don't have the same size as a mutisig and that the account is one of the proper types