### PR TITLE
Fix: Try Borrow Mut Lamports Typo

### DIFF
--- a/sdk/pinocchio/src/account_info.rs
+++ b/sdk/pinocchio/src/account_info.rs
@@ -299,7 +299,7 @@ impl AccountInfo {
         })
     }
 
-    /// Tries to get a read only reference to the lamport field, failing if the field
+    /// Tries to get a mutable reference to the lamport field, failing if the field
     /// is already borrowed in any form.
     pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<u64>, ProgramError> {
         // check if the account lamports are already borrowed


### PR DESCRIPTION
Not an issue, nothing urgent.
There was a simple typo in the `try_borrow_mut_lamports` documentation that I noticed while checking it.

